### PR TITLE
Minor improvement to code-clearing after flash.

### DIFF
--- a/Apps/PcmApps.sln
+++ b/Apps/PcmApps.sln
@@ -7,7 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PcmHammer", "PcmHammer\PcmH
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "Tests\Tests.csproj", "{0AA6F273-995D-4ADE-8CBB-DB1B6E8A0FCE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PcmLibrary", "PcmLibrary\PcmLibrary.csproj", "{0B317C5A-E078-4A96-8E7A-00601BCA1429}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PcmLibrary", "PcmLibrary\PcmLibrary.csproj", "{0B317C5A-E078-4A96-8E7A-00601BCA1429}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Apps/PcmLibrary/Messages/Protocol.Misc.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.Misc.cs
@@ -16,20 +16,20 @@ namespace PcmHacking
         }
 
         /// <summary>
-        /// Create a broadcast message telling the PCM to clear DTCs
+        /// Create a broadcast message telling all modules to clear diagnostic trouble codes.
         /// </summary>
-        public Message CreateClearDTCs()
+        public Message CreateClearDiagnosticTroubleCodesRequest()
         {
-            byte[] bytes = new byte[] { Priority.Functional0, 0x6A, DeviceId.Tool, Mode.ClearDTCs };
+            byte[] bytes = new byte[] { Priority.Functional0, 0x6A, DeviceId.Tool, Mode.ClearDiagnosticTroubleCodes };
             return new Message(bytes);
         }
 
         /// <summary>
-        /// A successfull response seen after the Clear DTCs message
+        /// Create a broadcast message telling all modules to clear diagnostic information.
         /// </summary>
-        public Message CreateClearDTCsOK()
+        public Message CreateClearPcmDiagnosticInformationRequest()
         {
-            byte[] bytes = new byte[] { 0x48, 0x6B, DeviceId.Pcm, Mode.ClearDTCs + Mode.Response };
+            byte[] bytes = new byte[] { Priority.Physical0High, DeviceId.Broadcast, DeviceId.Tool, Mode.ClearDiagnosticInformation };
             return new Message(bytes);
         }
 
@@ -56,7 +56,7 @@ namespace PcmHacking
         /// </summary>
         public Message ClearDTCs()
         {
-            byte[] bytes = new byte[] { Priority.Functional0, 0x6A, DeviceId.Tool, Mode.ClearDTCs };
+            byte[] bytes = new byte[] { Priority.Functional0, 0x6A, DeviceId.Tool, Mode.ClearDiagnosticTroubleCodes };
             return new Message(bytes);
         }
 
@@ -65,7 +65,7 @@ namespace PcmHacking
         /// </summary>
         public Message ClearDTCsOK()
         {
-            byte[] bytes = new byte[] { Priority.Functional0Low, 0x6B, DeviceId.Pcm, Mode.ClearDTCs + Mode.Response };
+            byte[] bytes = new byte[] { Priority.Functional0Low, 0x6B, DeviceId.Pcm, Mode.ClearDiagnosticTroubleCodes + Mode.Response };
             return new Message(bytes);
         }
 

--- a/Apps/PcmLibrary/Messages/Protocol.Misc.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.Misc.cs
@@ -27,7 +27,7 @@ namespace PcmHacking
         /// <summary>
         /// Create a broadcast message telling all modules to clear diagnostic information.
         /// </summary>
-        public Message CreateClearPcmDiagnosticInformationRequest()
+        public Message CreateClearDiagnosticInformationRequest()
         {
             byte[] bytes = new byte[] { Priority.Physical0High, DeviceId.Broadcast, DeviceId.Tool, Mode.ClearDiagnosticInformation };
             return new Message(bytes);

--- a/Apps/PcmLibrary/Messages/VPW.cs
+++ b/Apps/PcmLibrary/Messages/VPW.cs
@@ -135,7 +135,8 @@ namespace PcmHacking
         public const byte Response = 0x40; // added to the Mode by the PCM for it's the response
         public const byte Rejected = 0x75;
 
-        public const byte ClearDTCs = 0x04;
+        public const byte ClearDiagnosticTroubleCodes = 0x04;
+        public const byte ClearDiagnosticInformation = 0x14;
         public const byte ExitKernel = 0x20;
         public const byte Seed = 0x27;
         public const byte SilenceBus = 0x28;

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -131,13 +131,18 @@ namespace PcmHacking
             this.logger.AddDebugMessage("Halting the kernel.");
             await this.ExitKernel();
 
+            /* Waiting for the PCM to reboot didn't make any difference.
+             * But I still hope that if we send the right messages after
+             * restarting the PCM, we can clear the TAC's P1518 code.
+             * 
             this.logger.AddUserMessage("Waiting for the PCM to restart...");
             for(int remaining = 10; remaining > 0; remaining--)
             {
                 this.logger.AddUserMessage(remaining.ToString() + " seconds left.");
                 await Task.Delay(1000);
             }
-            this.logger.AddUserMessage("Clearing trouble codes.");
+            */
+
             await this.ClearTroubleCodes();
         }
 
@@ -171,6 +176,7 @@ namespace PcmHacking
         /// </remarks>
         public async Task ClearTroubleCodes()
         {
+            this.logger.AddUserMessage("Clearing trouble codes.");
             this.device.ClearMessageQueue();
 
             // The response is not checked because the priority byte and destination address are odd.
@@ -182,7 +188,7 @@ namespace PcmHacking
 
             // This is a conventional message, but the response from the PCM might get lost 
             // among the responses from other modules on the bus, so again we just send it twice.
-            Message clearDiagnosticInformationRequest = this.protocol.CreateClearPcmDiagnosticInformationRequest();
+            Message clearDiagnosticInformationRequest = this.protocol.CreateClearDiagnosticInformationRequest();
             await this.device.SendMessage(clearDiagnosticInformationRequest);
             await this.device.SendMessage(clearDiagnosticInformationRequest);
         }

--- a/Apps/PcmLibrary/Vehicle.Write.cs
+++ b/Apps/PcmLibrary/Vehicle.Write.cs
@@ -57,6 +57,8 @@ namespace PcmHacking
             bool needToCheckOperatingSystem,
             CancellationToken cancellationToken)
         {
+            bool success = false;
+
             try
             {
                 await notifier.Notify();
@@ -105,11 +107,10 @@ namespace PcmHacking
                     }
                 }
 
-                bool success = await Write(cancellationToken, image, writeType, notifier);
+                success = await Write(cancellationToken, image, writeType, notifier);
 
                 // We only do cleanup after a successful write.
                 // If the kernel remains running, the user can try to flash again without rebooting and reloading.
-                // TODO: kernel should send tool-present messages to keep itself in control.
                 // TODO: kernel version should be stored at a fixed location in the bin file.
                 // TODO: app should check kernel version (not just "is present") and reload only if version is lower than version in kernel file.
                 if (success)
@@ -121,13 +122,17 @@ namespace PcmHacking
             }
             catch (Exception exception)
             {
-                this.logger.AddUserMessage("Something went wrong. " + exception.Message);
-                this.logger.AddUserMessage("Do not power off the PCM! Do not exit this program!");
-                this.logger.AddUserMessage("Try flashing again. If errors continue, seek help online.");
-                this.logger.AddUserMessage("https://pcmhacking.net/forums/viewtopic.php?f=3&t=6080");
-                this.logger.AddUserMessage(string.Empty);
-                this.logger.AddUserMessage(exception.ToString());
-                return false;
+                if (!success)
+                {
+                    this.logger.AddUserMessage("Something went wrong. " + exception.Message);
+                    this.logger.AddUserMessage("Do not power off the PCM! Do not exit this program!");
+                    this.logger.AddUserMessage("Try flashing again. If errors continue, seek help online.");
+                    this.logger.AddUserMessage("https://pcmhacking.net/forums/viewtopic.php?f=3&t=6080");
+                    this.logger.AddUserMessage(string.Empty);
+                    this.logger.AddUserMessage(exception.ToString());
+                }
+
+                return success;
             }
         }
 


### PR DESCRIPTION
This is a small improvement but it still doesn't address the issue with a P1518 code after a write. I suspect that the fix to that will require sending a message after the PCM reboots, so the code that is still present in Cleanup() but is commented out. When we know what message to send we can add it to ClearTroubleCodes() and un-comment the wait-for-reboot code.