### PR TITLE
Force more frequent tool-present messages when using ScanTool LX/MX/etc.

### DIFF
--- a/Apps/PcmLibrary/Devices/ElmDevice.cs
+++ b/Apps/PcmLibrary/Devices/ElmDevice.cs
@@ -144,13 +144,23 @@ namespace PcmHacking
             // Consider increasing if STOPPED / NO DATA is still a problem. 
             this.Port.SetTimeout(milliseconds + 250);
 
+            // This code is so problematic that I've left it here as a warning. The app is
+            // unable to receive the response to the erase command if this code is enabled.
+            // 
+            //if (this.implementation is ScanToolDeviceImplementation)
+            //{
+            //    TimeoutScenario old = this.currentTimeoutScenario;
+            //    this.currentTimeoutScenario = scenario;
+            //    return old;
+            //}
+
             // I briefly tried hard-coding timeout values for the AT ST command,
             // but that's a recipe for failure. If the port timeout is shorter
             // than the device timeout, reads will consistently fail.
             int parameter = Math.Min(Math.Max(1, (milliseconds / 4)), 255);
             string value = parameter.ToString("X2");
             await this.implementation.SendAndVerify("AT ST " + value, "OK");
-
+            
             TimeoutScenario result = this.currentTimeoutScenario;
             this.currentTimeoutScenario = scenario;
             this.implementation.TimeoutScenario = scenario;

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -140,7 +140,14 @@ namespace PcmHacking
         /// <returns></returns>
         public async Task SendToolPresentNotification()
         {
-            await this.notifier.Notify();
+            if (!this.device.Supports4X && (this.device.MaxSendSize > 600 || this.device.MaxReceiveSize > 600))
+            {
+                await this.notifier.ForceNotify();
+            }
+            else
+            {
+                await this.notifier.Notify();
+            }
         }
 
         /// <summary>
@@ -156,9 +163,9 @@ namespace PcmHacking
         /// <summary>
         /// Change the device's timeout.
         /// </summary>
-        public async Task SetDeviceTimeout(TimeoutScenario scenario)
+        public async Task<TimeoutScenario> SetDeviceTimeout(TimeoutScenario scenario)
         {
-            await this.device.SetTimeout(scenario);
+            return await this.device.SetTimeout(scenario);
         }
 
         /// <summary>


### PR DESCRIPTION
This was the key thing to get in-car flashing to work.