### PR TITLE
MaxKernelSendSize / MaxFlashWriteSendSize

### DIFF
--- a/Apps/PcmLibrary/CKernelWriter.cs
+++ b/Apps/PcmLibrary/CKernelWriter.cs
@@ -455,7 +455,7 @@ namespace PcmHacking
             CancellationToken cancellationToken)
         {
             int retryCount = 0;
-            int devicePayloadSize = vehicle.DeviceMaxSendSize - 12; // Headers use 10 bytes, sum uses 2 bytes.
+            int devicePayloadSize = vehicle.DeviceMaxFlashWriteSendSize - 12; // Headers use 10 bytes, sum uses 2 bytes.
             for (int index = 0; index < range.Size; index += devicePayloadSize)
             {
                 if (cancellationToken.IsCancellationRequested)

--- a/Apps/PcmLibrary/Messages/VPW.cs
+++ b/Apps/PcmLibrary/Messages/VPW.cs
@@ -174,14 +174,15 @@ namespace PcmHacking
         /// <summary>
         /// Calculate the checksum for a given block of VPW data.
         /// </summary>
-        public static UInt16 CalcBlockChecksum(byte[] Block)
+        public static UInt16 CalcBlockChecksum(byte[] block)
         {
             UInt16 Sum = 0;
-            int PayloadLength = (Block[5] << 8) + Block[6];
+            int expectedLength = (block[5] << 8) + block[6];
+            if (expectedLength != (block.Length -2))
 
-            for (int i = 4; i < PayloadLength + 10; i++) // start after prio, dest, src, mode, stop at end of payload
+            for (int i = 4; i < expectedLength + 10; i++) // start after prio, dest, src, mode, stop at end of payload
             {
-                Sum += Block[i];
+                Sum += block[i];
             }
 
             return Sum;

--- a/Apps/PcmLibrary/Vehicle.Kernel.cs
+++ b/Apps/PcmLibrary/Vehicle.Kernel.cs
@@ -322,7 +322,7 @@ namespace PcmHacking
             await this.device.SetTimeout(TimeoutScenario.SendKernel);
 
             // Loop through the payload building and sending packets, highest first, execute on last
-            int payloadSize = device.MaxSendSize - 12; // Headers use 10 bytes, sum uses 2 bytes.
+            int payloadSize = device.MaxKernelSendSize - 12; // Headers use 10 bytes, sum uses 2 bytes.
             int chunkCount = payload.Length / payloadSize;
             int remainder = payload.Length % payloadSize;
 

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -65,11 +65,11 @@ namespace PcmHacking
             }
         }
 
-        public int DeviceMaxSendSize
+        public int DeviceMaxFlashWriteSendSize
         {
             get
             {
-                return this.device.MaxSendSize;
+                return this.device.MaxFlashWriteSendSize;
             }
         }
 
@@ -140,7 +140,7 @@ namespace PcmHacking
         /// <returns></returns>
         public async Task SendToolPresentNotification()
         {
-            if (!this.device.Supports4X && (this.device.MaxSendSize > 600 || this.device.MaxReceiveSize > 600))
+            if (!this.device.Supports4X && (this.device.MaxFlashWriteSendSize > 600 || this.device.MaxReceiveSize > 600))
             {
                 await this.notifier.ForceNotify();
             }


### PR DESCRIPTION
Created separate max send size properties for sending kernel and writing to flash.