### PR TITLE
P59 full write support

### DIFF
--- a/Kernels/common-readwrite.c
+++ b/Kernels/common-readwrite.c
@@ -86,7 +86,7 @@ void SendWriteSuccess(unsigned char code)
 	MessageBuffer[3] = 0x76;
 	MessageBuffer[4] = code;
 
-	WriteMessage(MessageBuffer, 4, Complete);
+	WriteMessage(MessageBuffer, 5, Complete);
 }
 
 void SendWriteFail(unsigned char callerError, unsigned char flashError)

--- a/Kernels/flash-amd.c
+++ b/Kernels/flash-amd.c
@@ -13,7 +13,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 uint32_t Amd_GetFlashId()
 {
-	SIM_CSBAR0 = 0x0006;
+	SIM_CSBAR0 = 0x0007;
 	SIM_CSORBT = 0x6820;
 
 	// Switch to flash into ID-query mode.

--- a/Kernels/write-kernel.c
+++ b/Kernels/write-kernel.c
@@ -201,25 +201,6 @@ void HandleEraseBlock()
 	address <<= 8;
 	address |= MessageBuffer[7];
 
-	// Only allow known addresses for AMD.
-	// Intel full write is tested
-	if ((flashIdentifier >> 16) == 1) {
-		switch (address)
-		{
-		//	case 0: // Boot
-		case 0x004000: // Parameters
-		case 0x006000: // Parameters
-		case 0x008000: // Calibration
-		case 0x010000: // Calibration (P59 upper portion)
-			break;
-
-		default:
-			VariableSleep(2);
-			SendReply(0, 0x05, 0xFF, 0xFE);
-			return;
-		}
-	}
-
 	uint8_t status = 0;
 
 	switch (flashIdentifier)


### PR DESCRIPTION
Removed guard rails, fixed a chip-select bit. 

Also fixed an off-by-one error that isn't related to P59 support.