### PR TITLE
Added ability to unlock PCM with erased parameter block.

### DIFF
--- a/Apps/PcmLibrary/Misc/KeyAlgorithm.cs
+++ b/Apps/PcmLibrary/Misc/KeyAlgorithm.cs
@@ -20,7 +20,16 @@ namespace PcmHacking
         {
             if ((algo >= 0) && (algo <= 255))
             {
-                return unchecked((UInt16)KeyAlgo(seed, algo));
+                if (seed != 0xFFFF)
+                {
+                    return unchecked((UInt16)KeyAlgo(seed, algo));
+                }
+                else
+                {
+                    // 0xFFFF seed is non-standard and indicates that Parameter block is not programmed
+                    // so the key is also 0xFFFF. This sometimes happens after SPS flashing.
+                    return 0xFFFF;
+                }
             }
             else
             {


### PR DESCRIPTION
It happened to me twice that Tech2 SPS does not program parameters block properly and leaves them erased (all 0xFFFF).
This commit allows to unlock PCM with such issue.
0xFFFF seed is not a standard value anyway, AFAIK.