### PR TITLE
STN Device Specific Timeout

### DIFF
--- a/Apps/PcmLibrary/Devices/ElmDevice.cs
+++ b/Apps/PcmLibrary/Devices/ElmDevice.cs
@@ -157,9 +157,7 @@ namespace PcmHacking
             // I briefly tried hard-coding timeout values for the AT ST command,
             // but that's a recipe for failure. If the port timeout is shorter
             // than the device timeout, reads will consistently fail.
-            int parameter = Math.Min(Math.Max(1, (milliseconds / 4)), 255);
-            string value = parameter.ToString("X2");
-            await this.implementation.SendAndVerify("AT ST " + value, "OK");
+            await this.implementation.SetTimeoutMilliseconds(milliseconds);
             
             TimeoutScenario result = this.currentTimeoutScenario;
             this.currentTimeoutScenario = scenario;

--- a/Apps/PcmLibrary/Devices/ElmDeviceImplementation.cs
+++ b/Apps/PcmLibrary/Devices/ElmDeviceImplementation.cs
@@ -98,6 +98,17 @@ namespace PcmHacking
         }
 
         /// <summary>
+        /// Set the timeout to the device. If this is set too low, the device
+        /// will return 'No Data'. ELM327 is limited to 1020 milliseconds maximum.
+        /// </summary>
+        public virtual async Task<bool> SetTimeoutMilliseconds(int milliseconds)
+        {
+           int parameter = Math.Min(Math.Max(1, (milliseconds / 4)), 255);
+           string value = parameter.ToString("X2");
+           return await this.SendAndVerify("AT ST " + value, "OK");
+        }
+
+        /// <summary>
         /// Send a message, do not expect a response.
         /// </summary>
         public virtual Task<bool> SendMessage(Message message)

--- a/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
+++ b/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
@@ -156,7 +156,7 @@ namespace PcmHacking
                         break;
 
                     case TimeoutScenario.EraseMemoryBlock:
-                        milliseconds = 1000;
+                        milliseconds = 3000;
                         break;
 
                     case TimeoutScenario.WriteMemoryBlock:

--- a/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
+++ b/Apps/PcmLibrary/Devices/ScanToolDeviceImplementation.cs
@@ -112,10 +112,10 @@ namespace PcmHacking
                     this.MaxReceiveSize = 128 + 12;
                 }
 
-                // Setting timeout to maximum. Since we use STPX commands, the device will stop
-                // listening when it receives the expected number of responses, rather than 
-                // waiting for the timeout.
-                this.Logger.AddDebugMessage(await this.SendRequest("AT ST FF"));
+                // Setting timeout to a large value. Since we use STPX commands,
+                // the device will stop listening when it receives the expected
+                // number of responses, rather than waiting for the timeout.
+                this.Logger.AddDebugMessage(await this.SendRequest("STPTO 3000"));
 
             }
             catch (Exception exception)
@@ -192,6 +192,17 @@ namespace PcmHacking
             }
 
             return milliseconds;
+        }
+
+        /// <summary>
+        /// Set the timeout to the device. If this is set too low, the device
+        /// will return 'No Data'. The ST Equivalent timeout command doesn't have
+        /// the same 1020 millisecond limit since it takes an integer milliseconds
+        /// as a paramter.
+        /// </summary>
+        public override async Task<bool> SetTimeoutMilliseconds(int milliseconds)
+        {
+           return await this.SendAndVerify("STPTO " + milliseconds, "OK");
         }
 
         /// <summary>


### PR DESCRIPTION
I was having issues getting a successful erase using PCM Hammer. I re-ran commands manually and was able to get a response from the running kernel of success, so I had assumed that the timeouts weren't long enough. It turns out, the ELM327 timeout command is capped at 1020 milliseconds, which wasn't quite enough to let the PCM I was using finish the EraseBlock() routine before I got the NoData response. Since PCMHammer already waited for 3 seconds for a reponse, I changed the ELM327 timeout command "AT ST XX" to "STPTO" to allow a longer than 1020 millisecond timeout, and finish erasing/flashing my PCM successfully.

I had made an assumption that the STN family of ELM327 compatible devices are all that are supported here. If that is an invalid assumption these changes might not be what we're looking for. I wanted to get a PR up though for what changes I had made to get my PCM erasing successfully in the hopes it will help someone else.

[PCMHacking.net "PCMHammer 015 Failed Erase](https://pcmhacking.net/forums/viewtopic.php?f=42&t=7187&start=10)