### PR TITLE
Add DotNet Build/Publish Action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,34 @@
+name: .NET
+
+on: [ push ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout Code
+
+    - uses: microsoft/setup-msbuild@v1.0.2
+      name: Setup MSBuild Path
+
+    - uses: NuGet/setup-nuget@v1.0.2
+      name: Setup NuGet
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+    - run: nuget restore Apps/PcmApps.sln
+      name: Restore NuGet Packages
+
+    - run: msbuild Apps/PcmApps.sln
+      name: Build Applications
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: PCMHacks-${{github.sha}}
+        path: |
+          Apps\PcmHammer\bin\Debug\
+          Apps\PcmLogger\bin\Debug\
+          Apps\VpwExplorer\bin\Debug\


### PR DESCRIPTION
Add a DotNet action to build and publish the three main applications.
This is helpful to determine that any code changes pushed to the repo
build successfully.

It also makes the applications available to test to those who don't
have a proper build environment setup. It does require you copy over
the kernel.bin file from a working install currently, but at least
it's easier than installing Visual Studio with the correct .NET
framework versions.

Gauging interest in adding a build process to the repo. I could see
not publishing the folders containing the built artifacts, but this is
helpful should someone try to commit code that doesn't build.