### PR TITLE
Byte to int conversion fixes.

### DIFF
--- a/Apps/PcmLibrary/Logging/LogRowParser.cs
+++ b/Apps/PcmLibrary/Logging/LogRowParser.cs
@@ -135,11 +135,15 @@ namespace PcmHacking
                         {
                             if (pcmParameter.IsSigned)
                             {
-                                value = BitConverter.ToInt16(payload, startIndex);
+                                Int16 temp = (Int16)(payload[startIndex] << 8);
+                                temp += (byte)payload[startIndex + 1];
+                                value = temp;
                             }
                             else
                             {
-                                value = BitConverter.ToUInt16(payload, startIndex);
+                                UInt16 temp = (UInt16)(payload[startIndex] << 8);
+                                temp += payload[startIndex + 1];
+                                value = temp;
                             }
 
                             startIndex += 2;

--- a/Apps/Tests/LoggingTests.cs
+++ b/Apps/Tests/LoggingTests.cs
@@ -45,8 +45,8 @@ namespace Tests
 
             Int16 int16 = -3000;
             UInt16 uint16 = 50000;
-            byte[] bytesOfSigned16 = BitConverter.GetBytes(int16);
-            Byte[] bytesOfUnsigned16 = BitConverter.GetBytes(uint16);
+            byte[] bytesOfSigned16 =   new byte[] { (byte) ((int16 & 0xFF00) >> 8), (byte) (int16 & 0xFF) };
+            byte[] bytesOfUnsigned16 = new byte[] { (byte) ((uint16 & 0xFF00) >> 8), (byte) (uint16 & 0xFF) };
 
             byte signed8Byte;
             unchecked


### PR DESCRIPTION
This fixes conversion of two-byte logger parameters into floating-point.