### PR TITLE
Enhanced Device Picker, Added -r commandline option to PcmHammer to Reset Device Configuration.

### DIFF
--- a/Apps/PcmHammer/CommandLineOptions.cs
+++ b/Apps/PcmHammer/CommandLineOptions.cs
@@ -16,5 +16,7 @@ namespace PcmHacking
         public string BinFilePath { get; set; }
         [Option("version", Required = false, HelpText = "Display version information")]
         public bool ShowVersion { get; set; }
+        [Option('r', Required = false, HelpText = "Reset device configuration")]
+        public bool ResetDeviceConfiguration { get; set; }
     }
 }

--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -419,8 +419,6 @@ namespace PcmHacking
                 ThreadPool.QueueUserWorkItem(new WaitCallback(LoadHelp));
                 ThreadPool.QueueUserWorkItem(new WaitCallback(LoadCredits));
 
-                await this.ResetDevice();
-
                 this.MinimumSize = new Size(800, 600);
 
                 if (string.IsNullOrWhiteSpace(Configuration.Settings.LogDirectory) || !Directory.Exists(Configuration.Settings.LogDirectory))
@@ -444,7 +442,10 @@ namespace PcmHacking
                 }
 
                 this.StatusUpdateReset();
+
                 ProcessCommandLine();
+
+                await this.ResetDevice();
             }
             catch (Exception exception)
             {
@@ -452,7 +453,6 @@ namespace PcmHacking
                 this.AddDebugMessage(exception.ToString());
             }
         }
-
 
         /// <summary>
         /// Parse cmdline parameters
@@ -467,11 +467,32 @@ namespace PcmHacking
                     {
                         WriteCalibration(o.BinFilePath);
                     }
+
                     if (o.ShowVersion)
                     {
                         Console.WriteLine(GetAppNameAndVersion());
                     }
+
+                    if (o.ResetDeviceConfiguration)
+                    {
+                        ResetDeviceConfiguration();
+                    }
                 });
+        }
+
+        /// <summary>
+        /// Reset Device Configuration
+        /// </summary>
+        /// <remarks>
+        /// Used by command line argument --resetdeviceconfig to reset device configuration
+        /// </remarks>
+        private void ResetDeviceConfiguration()
+        {
+            DeviceConfiguration.Settings.DeviceCategory = string.Empty;
+            DeviceConfiguration.Settings.SerialPortDeviceType = string.Empty;
+            DeviceConfiguration.Settings.J2534DeviceType = string.Empty;
+            DeviceConfiguration.Settings.SerialPort = string.Empty;
+            DeviceConfiguration.Settings.Save();
         }
 
         /// <summary>

--- a/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.Designer.cs
+++ b/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.Designer.cs
@@ -73,7 +73,7 @@ namespace PcmHacking
             this.j2534RadioButton.TabStop = true;
             this.j2534RadioButton.Text = "&J2534 Device";
             this.j2534RadioButton.UseVisualStyleBackColor = true;
-            this.j2534RadioButton.CheckedChanged += new System.EventHandler(this.j2534DeviceButton_CheckedChanged);
+            this.j2534RadioButton.CheckedChanged += new System.EventHandler(this.j2534RadioButton_CheckedChanged);
             // 
             // serialRadioButton
             // 

--- a/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
+++ b/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
@@ -87,6 +87,27 @@ namespace PcmHacking
                 this.status.Text = "You don't seem to have any serial ports or J2534 devices.";
             }
 
+            switch(DeviceConfiguration.Settings.DeviceCategory)
+            {
+                case DeviceConfiguration.Constants.DeviceCategorySerial:
+                    {
+                        if (this.serialDeviceList.Items.Count > 0)
+                        {
+                            this.serialRadioButton.Checked = true;
+                        }
+                    }
+                    break;
+
+                case DeviceConfiguration.Constants.DeviceCategoryJ2534:
+                    {
+                        if (this.j2534DeviceList.Items.Count > 0)
+                        {
+                            this.j2534RadioButton.Checked = true;
+                        }
+                    }
+                    break;
+            }
+
             SetDefault(
                 this.serialPortList, 
                 x => (x as SerialPortInfo)?.PortName,
@@ -159,6 +180,9 @@ namespace PcmHacking
         /// </summary>
         private void FillJ2534DeviceList()
         {
+            this.j2534DeviceList.Items.Add(prompt);
+            this.j2534DeviceList.SelectedIndex = 0;
+
             foreach(J2534.J2534Device device in J2534DeviceFinder.FindInstalledJ2534DLLs(this.logger))
             {
                 this.j2534DeviceList.Items.Add(device);
@@ -196,8 +220,10 @@ namespace PcmHacking
         {
             if (this.serialRadioButton.Checked)
             {
-                serialOptionsGroupBox.Enabled = true;
                 j2534OptionsGroupBox.Enabled = false;
+                J2534DeviceType = string.Empty;
+                j2534DeviceList.SelectedIndex = 0;
+                serialOptionsGroupBox.Enabled = true;
                 this.DeviceCategory = DeviceConfiguration.Constants.DeviceCategorySerial;
             }
         }
@@ -205,11 +231,14 @@ namespace PcmHacking
         /// <summary>
         /// Enable/disable different groups of controls depending of which device type the user has chosen.
         /// </summary>
-        private void j2534DeviceButton_CheckedChanged(object sender, EventArgs e)
+        private void j2534RadioButton_CheckedChanged(object sender, EventArgs e)
         {
             if (this.j2534RadioButton.Checked)
             {
                 serialOptionsGroupBox.Enabled = false;
+                SerialPortDeviceType = string.Empty;
+                serialDeviceList.SelectedIndex = 0;
+                serialPortList.SelectedIndex = 0;
                 j2534OptionsGroupBox.Enabled = true;
                 this.DeviceCategory = DeviceConfiguration.Constants.DeviceCategoryJ2534;
             }
@@ -242,7 +271,13 @@ namespace PcmHacking
         /// </summary>
         private void j2534DeviceList_SelectedIndexChanged(object sender, EventArgs e)
         {
-            this.J2534DeviceType = this.j2534DeviceList.SelectedItem?.ToString();
+            string item = this.j2534DeviceList.SelectedItem?.ToString();
+            if (item == prompt)
+            {
+                item = null;
+            }
+
+            this.J2534DeviceType = item;
         }
 
         /// <summary>


### PR DESCRIPTION
Example: PcmHammer.exe -r

Will start PcmHammer with no device selected, this is for those unfortunate occasions when a device is locked up disallowing access into PcmHammer.