### PR TITLE
Downgrade GitHub Runner

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,6 @@
 name: .NET
 
-on: [ push ]
+on: [ pull_request, push ]
 
 jobs:
   build:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Use Windows Server 2019 for the GitHub runner instead of the latest
version as of this writing, Windows Server 2022. The build tools aren't
available on Windows Server 2022 necessary to build this project.