### PR TITLE
Added Assembly Kernels and Loaders to Github CI.

### DIFF
--- a/.github/workflows/CheckBuild.yml
+++ b/.github/workflows/CheckBuild.yml
@@ -1,6 +1,7 @@
 #
 # Original works by ddub07 <github.com>
 # 03/01/2023 - GampyG28 <github.com> major overhaul, renamed and updated.
+# 04/16/2023 - GampyG28 <github.com> Added Assembly Kernels and Loaders
 #
 name: CheckBuild
 
@@ -21,22 +22,60 @@ jobs:
     - name: Create temporary artifact storage
       run: mkdir TemporaryArtifactStorage
 
-    - name: Build all Kernels
+    - name: Build C Kernels
       run: |
         cd Kernels
         #
-        # The following loop is the one location that needs to be updated when adding a new kernel!
+        # The following loop is the one location that needs to be updated when adding a new C kernel.
         #
-        for p in "P01 FF8000" "P04 FF9090" "P10 FFB800" "P12 FF2000"; do
+        for p in "P01 FF8000" "P10 FFB800" "P12 FF2000"; do
           pcm=${p%% *}
           address=${p##* }
+
           echo Building Kernel ":    ${pcm}"
-          make PREFIX=/usr/bin/m68k-linux-gnu- pcm=${pcm} address=${address}
-          echo     Copy-Item Kernel-${pcm}.bin to TemporaryArtifactStorage
+          make -f makefile PREFIX=/usr/bin/m68k-linux-gnu- pcm=${pcm} address=${address}
+          echo "    Copy-Item Kernel-${pcm}.bin to TemporaryArtifactStorage"
           cp Kernel-${pcm}.bin ../TemporaryArtifactStorage/
-          echo     Cleanup after ${pcm}
+          echo "    Cleanup after Kernel-${pcm}"
           echo
           make clean
+        done
+
+    - name: Build Assembly Kernels and Loaders
+      run: |
+        cd Kernels
+        #
+        # Each group is required to have 3 elements in the following order
+        # 1: PCM Moniker (P01 (includes P59), P04, P08, etc...)
+        # 2: Kernel Base Address
+        # 3: Loader Base Address or NOLOADER if a loader is not used.
+        #
+        for p in "P04 FF9090 FF9890" "E54 FF8F50 NOLOADER"; do
+          pcm="${p%% *}";
+          p="${p#* }"
+          address="${p%% *}"
+          p="${p#* }"
+          loader="${p%% *}"
+
+          echo "Building Kernel :    ${pcm}"
+          make -f makefile-assembly PREFIX=/usr/bin/m68k-linux-gnu- pcm=${pcm} address=${address}
+          echo "    Copy-Item Kernel-${pcm}.bin to TemporaryArtifactStorage"
+          cp Kernel-${pcm}.bin ../TemporaryArtifactStorage/
+          echo "    Cleanup after Kernel-${pcm}"
+          echo
+          make clean
+          #
+          # Build the Loader if requested
+          #
+          if [ ${loader} != NOLOADER ]; then
+            echo "Building Loader :    ${pcm}"
+            make -f makefile-assembly PREFIX=/usr/bin/m68k-linux-gnu- pcm=${pcm} address=${loader} name=Loader
+            echo "    Copy-Item Loader-${pcm}.bin to TemporaryArtifactStorage"
+            cp Loader-${pcm}.bin ../TemporaryArtifactStorage/
+            echo "    Cleanup after Loader-${pcm}"
+            echo
+            make clean
+          fi
         done
 
     - name: Upload artifacts

--- a/Kernels/makefile-assembly
+++ b/Kernels/makefile-assembly
@@ -1,0 +1,33 @@
+# Use toolchain from: https://github.com/haarer/toolchain68k
+# Configure for m68k-elf target and install to default location
+# 04/16/2023 - GampyG28 <github.com> Authored
+#
+pcm ?= P01
+address ?= FF8000
+name ?= Kernel
+
+PREFIX = /opt/crosschain/bin/m68k-elf-
+
+CC = $(PREFIX)gcc
+LD = $(PREFIX)ld
+OBJCOPY = $(PREFIX)objcopy
+RM = rm -f
+
+CCFLAGS = -c -fomit-frame-pointer -std=gnu99 -mcpu=68332 -D$(pcm)
+LDFLAGS = --section-start .text=0x${address} -T ${name}.ld 
+COPYFLAGS = -O binary --only-section=.text --only-section=.data
+
+all: ${name}.bin
+
+${name}.o: ${name}.S
+	$(CC) $(CCFLAGS) $< -o $@
+
+${name}.elf: ${name}.o
+	$(LD) $(LDFLAGS) $< -o $@
+
+${name}.bin: ${name}.elf
+	$(OBJCOPY) $(COPYFLAGS) ${name}.elf ${name}-${pcm}.bin
+
+clean:
+	${RM} *.bin *.o *.elf *.asm *.disassembly *.tmp
+


### PR DESCRIPTION
For those that do not know what Githubs CI does for you is this,
From the main PcmHacks repo page, Select `Actions`.
On the left margin Select `CheckBuild`.
In the middle, Click on a `Workflow Run` of your choice (Must be from this PR forward).
Scroll down to `Artifacts`.
The Artifact called `PcmHacks_<sha_number>` is a link to a Zipfile of PcmHammer at this point in time!
Click on it, Save it.
Go to your Downloads directory (or wherever you saved it).
Drag n drop it where you want to unzip it on the fly, adjust name accordingly in the Select Destination Dialog.
And Poof, there you have it, the latest and greatest PcmHammer test build!
Check it out, test it out ...

-Enjoy