### PR TITLE
Add P10+P12 OSIDs, Fix P08 as P04 bin. Add 1273057. 

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -1399,7 +1399,7 @@ namespace PcmHacking
                     FileValidator validator = new FileValidator(image, this);
                     if (!validator.IsValid())
                     {
-                        this.AddUserMessage("This file is corrupt. It would render your PCM unusable.");
+                        this.AddUserMessage("This file is corrupt or its format is unknown to PCMHammer. It would render your PCM unusable.");
                         return;
                     }
 
@@ -1638,7 +1638,7 @@ namespace PcmHacking
             }
             else
             {
-                this.AddUserMessage("This file is corrupt. It would render your PCM unusable.");
+                this.AddUserMessage("This file is corrupt or its format is unknown to PCMHammer. It would render your PCM unusable.");
             }
         }
     }

--- a/Apps/PcmHammer/credits.html
+++ b/Apps/PcmHammer/credits.html
@@ -16,7 +16,7 @@
     <p>
         <b>Antus</b>
         -
-        He and Dimented24x7 created the first free tool for reading and writing (LS1Flash) and he contributed enormously to this one.
+        He and Dimented24x7 created the first free tool for reading and writing (LS1Flash) and he contributed enormously to this one. More recently helping extend it to P10, P12 and P04.
     </p>
 
     <P>
@@ -28,7 +28,12 @@
     <p>
         <b>NSFW</b>
         -
-        Tried to write PCM Hammer despite knowing far too little about the hardware side of things... Was rescued by everyone else listed here.
+        Tried to write PCM Hammer despite knowing far too little about the hardware side of things... Was rescued by everyone else listed here (Antus says he's too modest)
+    </p>
+
+        <b>Gampyg28</b>
+        -
+        Gampy joined the project through the PCMHacking.net forums. First he contributed usability improvements, code tidyups, new features. Then improved build systems and pipelines. He has also developed the assembly kernels with Antus and worked on P10, P12 and P04 support.
     </p>
 
     <p>
@@ -43,14 +48,8 @@
         His code made it possible for PCM Hammer to support J2534 devices.
     </p>
 
-    <p>Tazzi and PeteS are also working on custom hardware that should provide high speed reading and writing at a low price - that's the "OBD Xpro" (formally DVI) that you see in the list of supported interfaces. Keep an eye out for updates.</p>
-
-    <p>
-        <b>Gampyg28</b>
-        -
-        Not one of the original crew, Gampy joined the project through the PCMHacking.net forums and has contributed a solid stream of usability improvements, codebase tidyups and new features. He shows no signs of slowing down.
-    </p>
-    
+    <p>Tazzi and PeteS have also built hardware that we recommend. That's the "OBD Xpro" that you see in the list of supported interfaces. It's Available from <a href="https://obdxpro.com/shop/">obdxpro.com</a>. GT, VX and VT are compatible with PCMHammer.</p>
+	       
     <p>
         And last but not least, thanks to the whole car-hacking community - to everyone who has looked under their hoods or into their OBD2 messages, and posted about it on the internet. And especially to everyone who has sent us words of encouragement along the way. It's always nice to be reminded that there are plenty more people out there who are just as stoked about this as we are!
     </p>

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -366,10 +366,20 @@ namespace PcmHacking
 
                 // P04 512Kb
                 this.logger.AddDebugMessage("Trying P04 512Kb");
-                if (((image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0x5A)) || // most
-                    ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A)))   // some 1998 eg Malibu L82 09369193
+                // Last 4 bytes:
+                // A5 5A FF FF = P04
+                // XX XX XX XX A5 5A = P04 (XX is the OSID)
+                if (((image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0x5A)) || // most P04 OR
+                    ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xFF) && (image[0x7FFFF] == 0xFF)))   // Most 1998 512Kb eg Malibu 09369193, Olds 09352676‬, LeSabre 09379801...
                 {
                         return PcmType.P04;
+                }
+
+                // P08 512Kb
+                this.logger.AddDebugMessage("Trying P08 512Kb");
+                if ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0xA5))
+                {
+                    return PcmType.P08;
                 }
 
                 this.logger.AddDebugMessage("Trying P10 512Kb");

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -370,7 +370,7 @@ namespace PcmHacking
                 // A5 5A FF FF = P04
                 // XX XX XX XX A5 5A = P04 (XX is the OSID)
                 if (((image[0x7FFFE] == 0xA5) && (image[0x7FFFF] == 0x5A)) || // most P04 OR
-                    ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xFF) && (image[0x7FFFF] == 0xFF)))   // Most 1998 512Kb eg Malibu 09369193, Olds 09352676‬, LeSabre 09379801...
+                    ((image[0x7FFFC] == 0xA5) && (image[0x7FFFD] == 0x5A) && (image[0x7FFFE] == 0xFF) && (image[0x7FFFF] == 0xFF)))   // Most 1998 512Kb eg Malibu 09369193, Olds 09352676, LeSabre 09379801...
                 {
                         return PcmType.P04;
                 }

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -11,6 +11,7 @@ namespace PcmHacking
         Undefined = 0, // required for failed osid test on binary file
         P01_P59,
         P04,
+        P08,
         P10,
         P12,
         E54,
@@ -356,6 +357,12 @@ namespace PcmHacking
                     this.ImageSize = 512 * 1024;
                     break;
 
+                case 1273057:
+                    this.KeyAlgorithm = 40;
+                    this.Description = "VCM Suite COS 1M";
+                    this.ImageBaseAddress = 0x0;
+                    this.ImageSize = 1024 * 1024;
+                    break;
                 //------- HPT COS -----------
                 case 1250013:
                 case 1250018:
@@ -2126,31 +2133,37 @@ namespace PcmHacking
                 case 12589166:
                 case 12589312:
                 case 12589586:
+                case 12592070: //2004 Saturn Ion Redline 2.0L
                 case 12593533:
+                case 12596925: //2005 Saturn Ion Redline 2.0L
                 case 12597778:
-                case 12597978:
-                case 12601774:
-                case 12601321: // 2006 LX9
-                case 12601904: // Saturn I4
-                case 12605256:
-                case 12605261:
-                case 12610624:
+                case 12597978: //2004 Saturn Ion Redline 2.0L
+                case 12598275: //2006 Chevy Cobalt SS 2.0L (Need to verify)
+                case 12598284: //2006 Saturn Ion Redline 2.0L
+                case 12601321: //2006 LX9
+                case 12601774: //2005 Chevy Cobalt SS 2.0L
+                case 12601904: //2005 Saturn Ion Redline 2.0L
+                case 12605256: //2006 Chevy Cobalt SS 2.0L
+                case 12605261: //2006 Chevy Cobalt SS 2.0L
+                case 12610624: //2007 Chevy Cobalt SS 2.0L & 2007 Saturn Ion Redline 2.0L
+                case 12610641: //GMS3 OS (04 Ion Redline GMS3)
+                case 12610642: //GMS3 OS (05 Ion Redline GMS3)
+                case 12610643: //GMS3 OS (06-07 Ion Redline GMS3)
+                case 12610644: //GMS3 OS (05 Cobalt SS GMS3)
+                case 12610645: //GMS3 OS (06-07 Cobalt SS GMS3)
                 case 12623279:
                 case 12627882:
                 case 12627884:
                 case 12631085:
-                // LL8 - Atlas I6 (4200) P12
-                case 12604440:
-                case 12606400:
-                // L52 - Atlas I5 (3500) P12
-                case 12606374:
-                case 12606375:
-                // LK5 - Atlas I4 (2800) P12
+                case 12604440: //LL8 - Atlas I6 (4200) P12
+                case 12606400: //2006 Chevy Trailblazer 4.2L (Atlas I6)
+                case 12606374: //L52 - Atlas I5 (3500) P12
+                case 12606375: //L52 - Atlas I5 (3500) P12
                 case 12627883:
-                // Saturn 1mb P12
+                    // Saturn 1mb P12
                     this.KernelFileName = "Kernel-P12.bin";
                     this.KernelBaseAddress = 0xFF2000; // or FF0000? https://pcmhacking.net/forums/viewtopic.php?f=42&t=7742&start=450#p115622
-                    this.RAMSize= 0x6000;
+                    this.RAMSize = 0x6000;
                     this.IsSupported = true;
                     this.KeyAlgorithm = 91;
                     this.Description = "P12 1m (Atlas I4/I5/I6)";
@@ -2163,7 +2176,7 @@ namespace PcmHacking
                 // P12 2m - See: https://pcmhacking.net/forums/viewtopic.php?f=42&t=7742&start=470#p115747
                 case 12609805:
                 case 12611642:
-                case 12613422:
+                case 12613422: //2007 Chevy Trailblazer 4.2L
                 case 12618164:
                 case 12627885:
                     this.KernelFileName = "Kernel-P12.bin";

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -2160,7 +2160,6 @@ namespace PcmHacking
                 case 12606374: //L52 - Atlas I5 (3500) P12
                 case 12606375: //L52 - Atlas I5 (3500) P12
                 case 12627883:
-                    // Saturn 1mb P12
                     this.KernelFileName = "Kernel-P12.bin";
                     this.KernelBaseAddress = 0xFF2000; // or FF0000? https://pcmhacking.net/forums/viewtopic.php?f=42&t=7742&start=450#p115622
                     this.RAMSize = 0x6000;


### PR DESCRIPTION
Add P10+P12 OSIDs, thanks spyder09 @ PCMHacking.net. Add P08 as a type. Fix P04 File validation picking up P08 bins. Add OSID 1273057.