### PR TITLE
Update some warning messages

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -1231,11 +1231,10 @@ namespace PcmHacking
                         AddUserMessage($"Using OsID: {pcmInfo.OSID}");
                     }
 
-                    if (pcmInfo.HardwareType == PcmType.P04)
+                    if (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.P08 || pcmInfo.HardwareType == PcmType.E54)
                     {
-                        this.AddUserMessage("WARNING: P04 Support i still in development.");
-                        this.AddUserMessage("It may or may not read your P04 correctly.");
-                        DialogResult dialogResult = MessageBox.Show("WARNING: P04 Read is still in development.\nIt may or may not read your P04 correctly.\n", "Continue?", MessageBoxButtons.YesNo);
+                        this.AddUserMessage("WARNING: P04, P08 & E54 support is still in development.");
+                        DialogResult dialogResult = MessageBox.Show("WARNING: P04, P08 & E54 support is still in development.\n", "Continue?", MessageBoxButtons.YesNo);
                         if (dialogResult == DialogResult.No)
                         {
                             this.AddUserMessage("User chose not to proceed");

--- a/Apps/PcmLibrary/Misc/Utility.cs
+++ b/Apps/PcmLibrary/Misc/Utility.cs
@@ -208,8 +208,6 @@ namespace PcmHacking
             {
                 logger.AddUserMessage(operation + "-request messages had to be re-sent " + retryCount + " times.");
             }
-
-            logger.AddUserMessage("We're not sure how much retrying is normal for a " + operation.ToLower() + " operation on a " + (pcmSize / 1024).ToString() + "kb PCM."); 
             logger.AddUserMessage("Please help by sharing your results in the PCM Hammer thread at pcmhacking.net.");
         }
 


### PR DESCRIPTION
Trigger the P04 warning also for P08 and E54. We can update this to say write is not supported once read testing is finished and before the next release.

Remove the note about being not sure how many retransmissions are normal.