### PR TITLE
Antus/e54filevalidation

### DIFF
--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -247,6 +247,7 @@ namespace PcmHacking
                 case PcmType.P04:
                 case PcmType.P05:
                 case PcmType.P08:
+                case PcmType.E54:
                     break;
 
                 case PcmType.Undefined:
@@ -271,13 +272,22 @@ namespace PcmHacking
                 case PcmType.P12:
                     this.logger.AddUserMessage("\tStart\tEnd\tStored\tNeeded\tVerdict\tSegment Name");
                     success &= ValidateRangeP12(0x922, 0x900, 0x94A, 2, "Boot Block");
-                    success &= ValidateRangeP12(0x8022, 0, 0x804A, 2, "OS");
+                    success &= ValidateRangeP12(0x8022, 0, 0x804A, 2, "Operating System");
                     success &= ValidateRangeP12(0x80C4, 0, 0x80E4, 2, "Engine Calibration");
                     success &= ValidateRangeP12(0x80F7, 0, 0x8117, 2, "Engine Diagnostics");
                     success &= ValidateRangeP12(0x812A, 0, 0x814A, 2, "Transmission Calibration");
                     success &= ValidateRangeP12(0x815D, 0, 0x817D, 2, "Transmission Diagnostics");
                     success &= ValidateRangeP12(0x805E, 0, 0x807E, 2, "Speedometer");
                     success &= ValidateRangeP12(0x8091, 0, 0x80B1, 2, "System");
+                    break;
+                case PcmType.E54:
+                    this.logger.AddUserMessage("\tStart\tEnd\tStored\tNeeded\tVerdict\tSegment Name");
+                    success &= ValidateRangeWordSum(type, 0x20002, 0x6FFFF, 0x20000, "Operating System");
+                    success &= ValidateRangeWordSum(type, 0x8002, 0x19FFF, 0x8000, "Engine Calibration");
+                    success &= ValidateRangeWordSum(type, 0x1A002, 0x1C7FF, 0x1A000, "Engine Diagnostics");
+                    success &= ValidateRangeWordSum(type, 0x1C002, 0x1DFFF, 0x1C000, "Fuel");
+                    success &= ValidateRangeWordSum(type, 0x1E002, 0x1EFFF, 0x1E000 , "System");
+                    success &= ValidateRangeWordSum(type, 0x1F002, 0x1FFEF, 0x1F000, "Speedometer");
                     break;
 
                 // The rest can use the generic code

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -174,14 +174,14 @@ namespace PcmHacking
                                 osid += image[0x7FFFC - offset] << 8;
                                 osid += image[0x7FFFD - offset] << 0;
                                 break;
-
-                            case 1024 * 1024:
-                                osid += image[0xFFFFA] << 24;
-                                osid += image[0xFFFFB] << 16;
-                                osid += image[0xFFFFC] << 8;
-                                osid += image[0xFFFFD] << 0;
-                                break;
                         }
+                        break;
+
+                    case PcmType.P05:
+                        osid += image[0xFFFFA] << 24;
+                        osid += image[0xFFFFB] << 16;
+                        osid += image[0xFFFFC] << 8;
+                        osid += image[0xFFFFD] << 0;
                         break;
 
                     case PcmType.P08:
@@ -239,6 +239,11 @@ namespace PcmHacking
                     segments = 0;
                     break;
 
+                case PcmType.P05:
+                    tableAddress = 0x0;
+                    segments = 0;
+                    break;
+
                 case PcmType.P10:
                     tableAddress = 0x546;
                     segments = 5;
@@ -260,6 +265,7 @@ namespace PcmHacking
             switch (type)
             {
                 case PcmType.P04:
+                case PcmType.P05:
                     this.logger.AddUserMessage("\tStart\tEnd\tStored\t\tNeeded\t\tVerdict\tSegment Name");
                     success &= ValidateRangeP04(true);
                     break;
@@ -429,11 +435,11 @@ namespace PcmHacking
                     }
                 }
 
-                // P04 512Kb
-                this.logger.AddDebugMessage("Trying P04 1Mb");
+                // P05 1Mb
+                this.logger.AddDebugMessage("Trying P05 1Mb");
                 if ((image[0xFFFFE] == 0xA5) && (image[0xFFFFF] == 0x5A))
                 {
-                    return PcmType.P04;
+                    return PcmType.P05;
                 }
 
                 this.logger.AddDebugMessage("Trying P12 1Mb");
@@ -592,7 +598,7 @@ namespace PcmHacking
         }
 
         /// <summary>
-        /// Validate a range for P04. Support 256, 512, 1024K images
+        /// Validate a range for P04 and P05. Support 256, 512, 1024K images
         /// Early 512KB bins dont have a param block. This code is called with skipparamblock=true
         /// If the first attempt fails it is re-entrant with skipparamblock=false to try again
         /// </summary>
@@ -605,7 +611,7 @@ namespace PcmHacking
             UInt32 sumaddr = 0;
 
             // Thanks Joukoy for Universal Patcher and the idea to use a pattern search for the P04 sum address.
-            // Working for all tested 1024K
+            // Working for all tested 1024K (P05)
             if (image.Length == 1024 * 1024)
             {
                 for (UInt32 i = start; i < end; i++)
@@ -698,7 +704,7 @@ namespace PcmHacking
                             address += 0x4; // Some 98 have a different sig and dont include the osid
                         }
                         break;
-                    case 1024 * 1024:
+                    case 1024 * 1024: // P05
                         if (address == 0x4000)
                         {
                             address += 0xC000;

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -11,6 +11,7 @@ namespace PcmHacking
         Undefined = 0, // required for failed osid test on binary file
         P01_P59,
         P04,
+        P05,
         P08,
         P10,
         P12,


### PR DESCRIPTION
Moves 'P04 1M' to P05.
Adds P08 File validation.
Adds E54 File validation.

I only have one E54 bin, works for me [tm], needs more testing.
Segments look hard coded, so pretty good chance they all fit this template.

P04 256Kb (which are no longer believed to be P04) still need to be identified and code moved to the right PCM type.