### PR TITLE
Antus/p08

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -864,7 +864,7 @@ namespace PcmHacking
                     this.AddUserMessage("Serial Number query failed: " + serialResponse.Status.ToString());
                 }
 
-                // Disable BCC lookup for the P04
+                // Disable BCC lookup for those that do not provide it
                 if (pcmInfo != null && pcmInfo.HardwareType != PcmType.P04 && pcmInfo.HardwareType != PcmType.P08)
                 {
                     var bccResponse = await this.Vehicle.QueryBCC();
@@ -1241,7 +1241,7 @@ namespace PcmHacking
                         AddUserMessage($"Using OsID: {pcmInfo.OSID}");
                     }
 
-                    if (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.P08 || pcmInfo.HardwareType == PcmType.E54)
+                    if (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.E54)
                     {
                         string msg = $"WARNING: {pcmInfo.HardwareType.ToString()} Support is still in development.";
                         this.AddUserMessage(msg);
@@ -1516,7 +1516,7 @@ namespace PcmHacking
                         }
                     }
 
-                    if (writeType != WriteType.Compare && (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.P08))
+                    if (writeType != WriteType.Compare && (pcmInfo.HardwareType == PcmType.P04))
                     {
                         string msg = $"PCMHammer currently does not support writing to the {pcmInfo.HardwareType.ToString()}";
                         this.AddUserMessage(msg);
@@ -1524,7 +1524,7 @@ namespace PcmHacking
                         return;
                     }
 
-                    if (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.P08 || pcmInfo.HardwareType == PcmType.E54)
+                    if (pcmInfo.HardwareType == PcmType.P04 || pcmInfo.HardwareType == PcmType.E54)
                     {
                         string msg = $"WARNING: {pcmInfo.HardwareType.ToString()} Support is still in development.";
                         this.AddUserMessage(msg);

--- a/Apps/PcmLibrary/CKernelReader.cs
+++ b/Apps/PcmLibrary/CKernelReader.cs
@@ -132,10 +132,16 @@ namespace PcmHacking
 
                 await this.vehicle.SetDeviceTimeout(TimeoutScenario.ReadMemoryBlock);
 
-                byte[] image = new byte[pcmInfo.ImageSize];
+                
+                int imageSize = pcmInfo.ImageSize;
                 int retryCount = 0;
                 int startAddress = 0;
-                int bytesRemaining = pcmInfo.ImageSize;
+
+                //startAddress = 0x0000; //uncomment to read a portion only when testing
+                //imageSize = 0xFFFF;
+
+                byte[] image = new byte[imageSize];
+                int bytesRemaining = imageSize;
                 int blockSize = this.vehicle.DeviceMaxReceiveSize - 10 - 2; // allow space for the header and block checksum
                 if (blockSize > this.pcmInfo.KernelMaxBlockSize)
                 {
@@ -143,7 +149,7 @@ namespace PcmHacking
                 }
 
                 DateTime startTime = DateTime.MaxValue;
-                while (startAddress < pcmInfo.ImageSize)
+                while (startAddress < imageSize)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -153,9 +159,9 @@ namespace PcmHacking
                     // The read kernel needs a short message here for reasons unknown. Without it, it will RX 2 messages then drop one.
                     await this.vehicle.ForceSendToolPresentNotification();
 
-                    if (startAddress + blockSize > pcmInfo.ImageSize)
+                    if (startAddress + blockSize > imageSize)
                     {
-                        blockSize = pcmInfo.ImageSize - startAddress;
+                        blockSize = imageSize - startAddress;
                     }
 
                     if (blockSize < 1)

--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -200,7 +200,7 @@ namespace PcmHacking
         {
             if (timeout == 0)
             {
-                timeout = 500;
+                timeout = 1000;
             }
 
             int TempCount = 0;

--- a/Apps/PcmLibrary/Misc/FileValidator.cs
+++ b/Apps/PcmLibrary/Misc/FileValidator.cs
@@ -141,7 +141,7 @@ namespace PcmHacking
         {
             int osid = 0;
 
-            if (image.Length == 512 * 1024 || image.Length == 1024 * 1024 || image.Length == 2048 * 1024) // bin valid sizes
+            if (image.Length == 256 * 1024 || image.Length == 512 * 1024 || image.Length == 1024 * 1024 || image.Length == 2048 * 1024) // bin valid sizes
             {
                 PcmType type = this.ValidateSignatures();
                 switch (type)

--- a/Apps/PcmLibrary/Misc/FlashChip.cs
+++ b/Apps/PcmLibrary/Misc/FlashChip.cs
@@ -62,24 +62,55 @@ namespace PcmHacking
                 case 0xFFFF4471:
                     var unused = new MemoryRange[]
                     {
-                        // These numbers and descriptions are straight from the intel 28F400B data sheet.
-                        // Notice that if you convert the 16 bit word sizes to decimal, they're all
-                        // half as big as the description here, in bytes, indicates.
-                        new MemoryRange(0x30000, 0x10000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x20000, 0x10000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x10000, 0x10000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x04000, 0x0C000, BlockType.Calibration), //  96kb main block
-                        new MemoryRange(0x03000, 0x01000, BlockType.Parameter), //   8kb parameter block
-                        new MemoryRange(0x02000, 0x01000, BlockType.Parameter), //   8kb parameter block
-                        new MemoryRange(0x00000, 0x02000, BlockType.Boot), //  16kb boot block
+                        // These addresses are for a bottom fill chip (B) in byte mode (not word).
+                        // Be careful which notation datasheets are using when adding more devices.
+                        new MemoryRange(0x60000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x40000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x20000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block 
+                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
                     };
                     throw new InvalidOperationException("This flash chip ID was not supposed to exist in the wild.");
 
+                // This is not a real chip, its used as a default value, then overwritten with real data if the kernel supprot flashchipid.
                 case 0x12345678:
-                    // P04 is too small to have chip ID code (at this stage). So, we use this hard coded ID to satisfy PCMHammer's need for a chip structure.
-                    // 12345678 should not exist in the wild and is less likely to trigger accidentally than using 00000000 or FFFFFFFF.
                     size = 512 * 1024;
-                    description = "Hardcoded Intel Specification 512kb";
+                    description = "Default 512Kb";
+                    memoryRanges = new MemoryRange[]
+                    {
+                        // Used by CKernelReader to initialise FlashChip default value
+                        new MemoryRange(0x60000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x40000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x20000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block 
+                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
+                    };
+                    break;
+
+                // Intel 28F200BX
+                case 0x00892274:
+                case 0x00892275:
+                    size = 256 * 1024;
+                    description = "Intel 28F200BX, 256kb";
+                    memoryRanges = new MemoryRange[]
+                    {
+                        // These addresses are for a bottom fill chip (B) in byte mode (not word)
+                        new MemoryRange(0x20000, 0x20000, BlockType.OperatingSystem), // 128kb main block
+                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block 
+                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
+                    };
+                    break;
+
+                // Intel 28F400B
+                case 0x00894471:
+                    size = 512 * 1024;
+                    description = "Intel 28F400B, 512kb";
                     memoryRanges = new MemoryRange[]
                     {
                         // These addresses are for a bottom fill chip (B) in byte mode (not word)
@@ -107,47 +138,30 @@ namespace PcmHacking
                         new MemoryRange(0x60000, 0x20000, BlockType.OperatingSystem), // 128kb main block
                         new MemoryRange(0x40000, 0x20000, BlockType.OperatingSystem), // 128kb main block
                         new MemoryRange(0x20000, 0x20000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block 
+                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block
                         new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //   8kb parameter block
                         new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //   8kb parameter block
                         new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
                     };
                     break;
 
-                // Intel 28F400B
-                case 0x00894471:
+                // AM29F400BB
+                case 0x000122AB:
                     size = 512 * 1024;
-                    description = "Intel 28F400B, 512kb";
+                    description = "AMD AM29F400BB, 512kb";
                     memoryRanges = new MemoryRange[]
                     {
-                        // These addresses are for a bottom fill chip (B) in byte mode (not word)
-                        new MemoryRange(0x60000, 0x20000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x40000, 0x20000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x20000, 0x20000, BlockType.OperatingSystem), // 128kb main block
-                        new MemoryRange(0x08000, 0x18000, BlockType.Calibration), //  96kb main block 
-                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //   8kb parameter block
-                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //   8kb parameter block
+                        new MemoryRange(0x70000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x60000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x50000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x40000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x30000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x20000, 0x10000, BlockType.OperatingSystem), //  64kb main block
+                        new MemoryRange(0x10000, 0x10000, BlockType.Calibration), //  64kb calibration block
+                        new MemoryRange(0x08000, 0x08000, BlockType.Calibration), //  32kb calibration block
+                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //  8kb parameter block
+                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //  8kb parameter block
                         new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
-                    };
-                    break;
-
-                // AM29BL162C
-                case 0x00012203:
-                    size = 2048 * 1024;
-                    description = "AMD AM29BL162C, 2mb";
-                    memoryRanges = new MemoryRange[]
-                    {           // Start address, Size in Bytes
-                        new MemoryRange(0x1C0000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange(0x180000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange(0x140000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange(0x100000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange( 0xC0000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange( 0x80000, 0x40000, BlockType.OperatingSystem), // 256kb main block
-                        new MemoryRange( 0x40000, 0x40000, BlockType.Calibration),     // 256kb calibration block
-                        new MemoryRange( 0x08000, 0x38000, BlockType.Calibration),     // 229kb calibration block
-                        new MemoryRange( 0x06000, 0x02000, BlockType.Parameter),       //   8kb parameter block
-                        new MemoryRange( 0x04000, 0x02000, BlockType.Parameter),       //   8kb parameter block
-                        new MemoryRange( 0x00000, 0x04000, BlockType.Boot),            //  16kb boot block
                     };
                     break;
 
@@ -197,23 +211,23 @@ namespace PcmHacking
                     };
                     break;
 
-                // AM29F400BB   
-                case 0x000122AB:
-                    size = 512 * 1024;
-                    description = "AMD AM29F400BB, 512kb";
+                // AM29BL162C
+                case 0x00012203:
+                    size = 2048 * 1024;
+                    description = "AMD AM29BL162C, 2mb";
                     memoryRanges = new MemoryRange[]
-                    {
-                        new MemoryRange(0x70000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x60000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x50000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x40000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x30000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x20000, 0x10000, BlockType.OperatingSystem), //  64kb main block
-                        new MemoryRange(0x10000, 0x10000, BlockType.Calibration), //  64kb calibration block
-                        new MemoryRange(0x08000, 0x08000, BlockType.Calibration), //  32kb calibration block
-                        new MemoryRange(0x06000, 0x02000, BlockType.Parameter), //  8kb parameter block
-                        new MemoryRange(0x04000, 0x02000, BlockType.Parameter), //  8kb parameter block
-                        new MemoryRange(0x00000, 0x04000, BlockType.Boot), //  16kb boot block
+                    {           // Start address, Size in Bytes
+                        new MemoryRange(0x1C0000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange(0x180000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange(0x140000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange(0x100000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange( 0xC0000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange( 0x80000, 0x40000, BlockType.OperatingSystem), // 256kb main block
+                        new MemoryRange( 0x40000, 0x40000, BlockType.Calibration),     // 256kb calibration block
+                        new MemoryRange( 0x08000, 0x38000, BlockType.Calibration),     // 229kb calibration block
+                        new MemoryRange( 0x06000, 0x02000, BlockType.Parameter),       //   8kb parameter block
+                        new MemoryRange( 0x04000, 0x02000, BlockType.Parameter),       //   8kb parameter block
+                        new MemoryRange( 0x00000, 0x04000, BlockType.Boot),            //  16kb boot block
                     };
                     break;
 
@@ -257,9 +271,9 @@ namespace PcmHacking
                 if (index == 0)
                 {
                     UInt32 top = memoryRanges[index].Address + memoryRanges[index].Size;
-                    if ((top != 512 * 1024) && (top != 1024 * 1024) && (top != 2048 * 1024))
+                    if ((top != 256 * 1024) && (top != 512 * 1024) && (top != 1024 * 1024) && (top != 2048 * 1024))
                     {
-                        throw new InvalidOperationException(chipIdString + " - Upper end of memory range must be 512k or 1024k, is " + top.ToString("X8"));
+                        throw new InvalidOperationException(chipIdString + " - Upper end of memory range must be 256k, 512k, 1024k or 2048k, is " + (top / 1024).ToString() + "k");
                     }
 
                     if (size != top)

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -2096,9 +2096,9 @@ namespace PcmHacking
                     this.ValidationMethod = PcmType.P04;
                     this.HardwareType = PcmType.P04;
                     this.KernelFileName = "Kernel-P04.bin";
-                    this.KernelBaseAddress = 0xFF9090;
+                    this.KernelBaseAddress = 0xFF8000;
                     this.LoaderFileName = "Loader-P04.bin";
-                    this.LoaderBaseAddress = 0xFF9890;
+                    this.LoaderBaseAddress = 0xFF9800;
                     //this.ImageBaseAddress = 0x0;
                     this.ImageSize = 512 * 1024;
                     //this.RAMSize = 0x0;

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -2116,19 +2116,17 @@ namespace PcmHacking
                 case 12208154:
                 case 12208773:
                     this.Description = "P08";
-                    this.IsSupported = false;
-                    this.LoaderRequired = true;
+                    this.IsSupported = true;
+                    this.LoaderRequired = false;
                     this.ValidationMethod = PcmType.P08;
                     this.HardwareType = PcmType.P08;
                     this.KernelFileName = "Kernel-P08.bin";
-                    this.KernelBaseAddress = 0xFFA800;
-                    this.LoaderFileName = "Loader-P08.bin";
-                    this.LoaderBaseAddress = 0xFFB000;
+                    this.KernelBaseAddress = 0xFFAC00;
                     this.ImageBaseAddress = 0x0;
                     this.ImageSize = 512 * 1024;
                     //this.RAMSize = 0x4DFF;
                     this.KeyAlgorithm = 13;
-                    this.ChecksumSupport = false;
+                    this.ChecksumSupport = true;
                     this.FlashCRCSupport = true;
                     this.FlashIDSupport = true;
                     this.KernelVersionSupport = true;

--- a/Apps/PcmLibrary/Misc/PcmInfo.cs
+++ b/Apps/PcmLibrary/Misc/PcmInfo.cs
@@ -608,6 +608,129 @@ namespace PcmHacking
                     this.HardwareType = PcmType.BLACKBOX;
                     break;
 
+                // 1996/1997 256kb V6 Service number 16207326
+                case 9352140:
+                case 9352142:
+                case 9352143:
+                case 9352146:
+                case 9352149:
+                case 9352150:
+                case 9352340:
+                case 9352342:
+                case 9352346:
+                case 9352347:
+                case 9352553:
+                case 9354241:
+                case 9354242:
+                case 9355430:
+                case 9355433:
+                case 9355435:
+                case 9365005:
+                case 9365007:
+                case 9365012:
+                case 9365017:
+                case 9365650:
+                case 9365651:
+                case 9365652:
+                case 9365655:
+                case 9367092:
+                case 16210002:
+                case 16210010:
+                case 16219361:
+                case 16219368:
+                case 16226502:
+                case 16227925:
+                case 16230131:
+                case 16230375:
+                case 16230378:
+                case 16230380:
+                case 16230383:
+                case 16230385:
+                case 16231872:
+                case 16231877:
+                case 16231889:
+                case 16231890:
+                case 16231940:
+                case 16231941:
+                case 16232010:
+                case 16232466:
+                case 16232477:
+                case 16233470:
+                case 16233471:
+                case 16233472:
+                case 16233478:
+                case 16234097:
+                case 16234124:
+                case 16234438:
+                case 16234440:
+                case 16234441:
+                case 16234751:
+                case 16235667:
+                case 16238373:
+                case 16238443:
+                case 16238446:
+                case 16238447:
+                case 16238448:
+                case 16238450:
+                case 16238452:
+                case 16238453:
+                case 16238456:
+                case 16238457:
+                case 16238458:
+                case 16238517:
+                case 16238518:
+                case 16238519:
+                case 16238520:
+                case 16238523:
+                case 16238525:
+                case 16238532:
+                case 16238533:
+                case 16240637:
+                case 16241229:
+                case 16245321:
+                case 16246063:
+                case 16246066:
+                case 16249992:
+                case 16249995:
+                case 16251203:
+                case 16251205:
+                case 16251975:
+                case 16257917:
+                case 16257918:
+                case 16257922:
+                case 16257926:
+                case 16257935:
+                case 16257936:
+                case 16257937:
+                case 16257938:
+                case 16257940:
+                case 16257942:
+                case 16257947:
+                case 16257950:
+                case 16257952:
+                case 16257953:
+                case 16257955:
+                case 16257956:
+                    this.Description = "1996/1997 256Kb V6";
+                    this.IsSupported = true;
+                    this.LoaderRequired = true;
+                    this.ValidationMethod = PcmType.P04;
+                    this.HardwareType = PcmType.P04;
+                    this.KernelFileName = "Kernel-P04.bin";
+                    this.KernelBaseAddress = 0xFF8000;
+                    this.LoaderFileName = "Loader-P04.bin";
+                    this.LoaderBaseAddress = 0xFF9800;
+                    //this.ImageBaseAddress = 0x0;
+                    this.ImageSize = 256 * 1024;
+                    //this.RAMSize = 0x0;
+                    this.KeyAlgorithm = 6;
+                    this.ChecksumSupport = true;
+                    this.FlashCRCSupport = true;
+                    this.FlashIDSupport = true;
+                    this.KernelVersionSupport = true;
+                    //this.KernelMaxBlockSize = 4096;
+                    break;
+
                 // P04 V6 Service number 9374997
                 case 9355672:
                 case 9356706:

--- a/Apps/PcmLibrary/Vehicle.cs
+++ b/Apps/PcmLibrary/Vehicle.cs
@@ -296,7 +296,14 @@ namespace PcmHacking
                 if (this.protocol.IsUnlocked(seedResponse.GetBytes()))
                 {
                     this.logger.AddUserMessage("PCM is already unlocked");
-                    return true;
+                    if (UserDefinedKey >= 0)
+                    {
+                        this.logger.AddUserMessage("Continuing unlock process with user defined key");
+                    }
+                    else
+                    {
+                        return true;
+                    }
                 }
 
                 this.logger.AddDebugMessage("Parsing seed value.");
@@ -317,7 +324,9 @@ namespace PcmHacking
                 return false;
             }
 
-            if (seedValue == 0x0000)
+            // if we have a user defined key the user might be trying to recover from a corrupted param block
+            // so we still let it though
+            if ((seedValue == 0x0000) && (UserDefinedKey == -1)) 
             {
                 this.logger.AddUserMessage("PCM Unlock not required");
                 return true;

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -54,7 +54,7 @@ REM   "-pP04 -aFF9090 -lFF9890 -x",
 
 for %%A in (
   "-pP01 -aFF8000 -x",
-  "-pP04 -aFF9090 -lFF9890 -x",
+  "-pP04 -aFF8000 -lFF9890 -x",
   "-pP08 -aFFAC00 -x",
   "-pP10 -aFFB800 -x",
   "-pP12 -aFF2000 -x",

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -55,8 +55,9 @@ REM   "-pP04 -aFF9090 -lFF9890 -x",
 for %%A in (
   "-pP01 -aFF8000 -x",
   "-pP04 -aFF8000 -lFF9890 -x",
-  "-pP08 -aFFA000 -lFFAC00 -x",
+  "-pP08 -aFFAC00 -x",
   "-pP10 -aFFB800 -x",
   "-pP12 -aFF2000 -x",
   "-pE54 -aFF8F50 -x"
   ) do call Build.cmd %%~A %*
+

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -55,9 +55,8 @@ REM   "-pP04 -aFF9090 -lFF9890 -x",
 for %%A in (
   "-pP01 -aFF8000 -x",
   "-pP04 -aFF8000 -lFF9890 -x",
-  "-pP08 -aFFAC00 -x",
+  "-pP08 -aFFA000 -lFFAC00 -x",
   "-pP10 -aFFB800 -x",
   "-pP12 -aFF2000 -x",
   "-pE54 -aFF8F50 -x"
   ) do call Build.cmd %%~A %*
-

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -54,7 +54,7 @@ REM   "-pP04 -aFF9090 -lFF9890 -x",
 
 for %%A in (
   "-pP01 -aFF8000 -x",
-  "-pP04 -aFF8000 -lFF9890 -x",
+  "-pP04 -aFF8000 -lFF9800 -x",
   "-pP08 -aFFAC00 -x",
   "-pP10 -aFFB800 -x",
   "-pP12 -aFF2000 -x",

--- a/Kernels/BuildAll.cmd
+++ b/Kernels/BuildAll.cmd
@@ -55,7 +55,7 @@ REM   "-pP04 -aFF9090 -lFF9890 -x",
 for %%A in (
   "-pP01 -aFF8000 -x",
   "-pP04 -aFF9090 -lFF9890 -x",
-  "-pP08 -aFFA800 -lFFB000 -x",
+  "-pP08 -aFFAC00 -x",
   "-pP10 -aFFB800 -x",
   "-pP12 -aFF2000 -x",
   "-pE54 -aFF8F50 -x"

--- a/Kernels/Common-Assembly.h
+++ b/Kernels/Common-Assembly.h
@@ -43,7 +43,8 @@
 .equ pcmid,              0x10
 
 | Modes supported
-.equ KernelID_3D00,      0x3D00        | Return the Kernel version (Id).
+.equ KernelMode,         0x3D          | Mode for Kernel functions
+.equ KernelID_3D00,      0x00          | Return the Kernel version (Id).
 .equ Halt_20,            0x20          | Reset PCM (Halt Kernel)
 .equ Mode_34,            0x34          | Request Permission to upload X bytes to Address
 .equ Mode_36,            0x36          | Tool sending data for writing to RAM or Flash.

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -425,7 +425,7 @@ ProcessWriteFlash:
 
     | Intel
     cmp.w   #INTEL_ID, %d1             | Intel manufacturer ID
-    beq.s   ProcessWriteFlashIntel     | Intel glash write
+    beq.s   ProcessWriteFlashIntel     | Intel flash write
 
     | AMD
     cmp.w   #AMD_ID, %d1               | AMD manufacturer ID
@@ -670,14 +670,20 @@ IntelFlashUnlock:
     move.w  #0x0007, (SIM_CSBAR0).w    | $FFFFFA4C
     | Unlock
     move.w  #0x7060, (SIM_CSOR0).w     | $FFFFFA4E
+
     | Enable +12v Vpp
-#if defined P08
-    bset    #VPP_BIT, (HARDWARE_IO).w  | Does not work on P01, needed for P08
+#if defined P04
+    clr.w   %d0                        | P04 needs this syntax
+    bset    #VPP_BIT, %d0
+    move.w  %d0, (HARDWARE_IO).w
+#elif defined P08
+    bset    #VPP_BIT, (HARDWARE_IO).w  | P08 needs this syntax
 #else
     move.w  (HARDWARE_IO).w, %d1       | Move Vpp Latch Address value to d1
     bset    #VPP_BIT, %d1              | Set Vpp Latch Bit
     move.w  %d1, (HARDWARE_IO).w       | Move modified value back to Latch Address
 #endif
+
     bsr.w   LongWaitWithWatchdog
     rts
 
@@ -707,14 +713,19 @@ IntelFlashLock:
     move.w  #0x0007, (SIM_CSBAR0).w    | $FFFFFA4C
     | Lock
     move.w  #0x1060, (SIM_CSOR0).w     | $FFFFFA4E
+
     | Disable +12v Vpp
-#if defined P08
+#if defined P04
+    clr.w   %d0                        | P04 needs this syntax
+    move.w  %d0, (HARDWARE_IO).w
+#elif defined P08
     bclr    #VPP_BIT, (HARDWARE_IO).w  | Does not work on P01, needed for P08
 #else
     move.w  (HARDWARE_IO).w, %d1       | Move Vpp Latch Address value to d1
     bclr    #VPP_BIT, %d1              | Set Vpp Latch Bit
     move.w  %d1, (HARDWARE_IO).w       | Move modified value back to Latch Address
 #endif
+
     bsr.w   LongWaitWithWatchdog
     rts
 
@@ -816,7 +827,7 @@ IntelWriteSectorNotReady:
     cmp.w   #0x080, %d3                 | Check status
     bne.s   IntelWriteSectorFail       | Fail Jump
 
-    subq    #2, %d0                    | Deincrement byte count by two (1 word)
+    subq    #2, %d7                    | Deincrement byte count by two (1 word)
     bne.s   IntelWriteSectorLoop       | Next word if not done
 
     clr.l   %d0                        | Set Success
@@ -878,6 +889,7 @@ ProcessMode35:
 |   d2
 |   d3
 |   d4
+|   d7 - Outputs Packet Length
 |
 ProcessMode36:
     clr.l   %d0                        | Clear for Target Address
@@ -890,16 +902,16 @@ ProcessMode36:
     movea.l %d0, %a1                   | Pointer to target address
     movea.l %d0, %a2                   | Pointer to target address for execute jump
 
-    clr.l   %d0                        | Start Clean
-    or.b    MessageBuffer + 5, %d0     | First length byte
-    lsl.l   #8, %d0                    | Logical Shift Left
-    or.b    MessageBuffer + 6, %d0     | Second length byte
+    clr.l   %d7                        | Start Clean
+    or.b    MessageBuffer + 5, %d7     | First length byte
+    lsl.l   #8, %d7                    | Logical Shift Left
+    or.b    MessageBuffer + 6, %d7     | Second length byte
 
 | Process Mode36 Validate Sum          | a3 = buffer address, d2 = temp, d3 = counter, d4=sum
     clr.l   %d2                        | Init temporary register
     movea.l #MessageBuffer + 4, %a3    | Pointer to beginning of checksum range, Calculates from MessageBuffer[4] (0=6C 1=10 2=F0 3=36 4=<start>)
     clr.l   %d4                        | Init sum
-    move.l  %d0, %d3                   | Payload length (Byte count)
+    move.l  %d7, %d3                   | Payload length (Byte count)
     addq.l  #5, %d3                    | Add submode (1), address (3), length(2) = 6 bytes to sum length minus 1 for Zero Index
 
 ProcessMode36NextSum:

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -362,7 +362,7 @@ ProcessEraseSector:
     clr.l   %d0                        | Start Clean
     movea.l #FlashIDReply, %a1         | Pointer to FlashIDReply buffer
 
-    move.b  5(%a1), %d1
+    move.b  5(%a1), %d1                | Copy the manufacturer ID to d1
     lsl.l   #8, %d1
     move.b  6(%a1), %d1
 
@@ -413,7 +413,9 @@ ProcessEraseSectorFinal:
 |
 ProcessWriteFlash:
     movea.l #FlashIDReply, %a2         | Pointer to FlashIDReply buffer
-    move.w  7(%a2), %d1                | Move Flash Chip ID to d1
+    move.b  5(%a2), %d1                | Copy the manufacturer ID to d1
+    lsl.l   #8, %d1
+    move.b  6(%a2), %d1
 
     | Intel
     cmp.w   #INTEL_ID, %d1             | Intel manufacturer ID

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -670,7 +670,13 @@ IntelFlashUnlock:
     | Unlock
     move.w  #0x7060, (SIM_CSOR0).w     | $FFFFFA4E
     | Enable +12v Vpp
-    bset    #VPP_BIT, (HARDWARE_IO).w  | Set Vpp
+#if defined P08
+    bset    #VPP_BIT, (HARDWARE_IO).w  | Does not work on P01, needed for P08
+#else
+    move.w  (HARDWARE_IO).w, %d1       | Move Vpp Latch Address value to d1
+    bset    #VPP_BIT, %d1              | Set Vpp Latch Bit
+    move.w  %d1, (HARDWARE_IO).w       | Move modified value back to Latch Address
+#endif
     bsr.w   LongWaitWithWatchdog
     rts
 
@@ -701,9 +707,14 @@ IntelFlashLock:
     | Lock
     move.w  #0x1060, (SIM_CSOR0).w     | $FFFFFA4E
     | Disable +12v Vpp
-    bclr    #VPP_BIT, (HARDWARE_IO).w  | Clear Vpp
+#if defined P08
+    bclr    #VPP_BIT, (HARDWARE_IO).w  | Does not work on P01, needed for P08
+#else
+    move.w  (HARDWARE_IO).w, %d1       | Move Vpp Latch Address value to d1
+    bclr    #VPP_BIT, %d1              | Set Vpp Latch Bit
+    move.w  %d1, (HARDWARE_IO).w       | Move modified value back to Latch Address
+#endif
     bsr.w   LongWaitWithWatchdog
-
     rts
 
 | =============== S U B R O U T I N E =======================================

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -407,7 +407,7 @@ ProcessEraseSectorFinal:
 | Entry
 |   a0 - Source Address
 |   a1 - Destination Address
-|   d0 - Byte Count
+|   d7 - Byte Count
 |
 | Exit
 |   d0 - Status 0=Ok, 1=Fail
@@ -584,7 +584,7 @@ AMDEraseSectorFinish:
 | Entry
 |   a0 - Source Address
 |   a1 - Destination Address
-|   d0 - Byte count - must be divisible by 2
+|   d7 - Byte count - must be divisible by 2
 |
 | Exit
 |   d0 - Status 0=Ok, 1=Fail
@@ -607,9 +607,6 @@ AMDWriteSector:
 
 AMDWriteSectorLoop:
     move.w  #2346, %d2                 | FlashNotReady Loop Timeout index
-
-    | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
-    | So we make words out of bytes ...
     clr.l   %d3                        | Start clean
     or.b    (%a0)+, %d3                | First byte, increment source to next byte
     lsl.l   #8, %d3                    | Logical Shift Left (shift byte left into upper word)
@@ -634,7 +631,7 @@ AMDWriteSectorNotReady:
 
 AMDWriteSectorSuccess:
     adda.w  #2, %a1                    | Increment address by 2 bytes (1 word)
-    subq.w  #2, %d0                    | Deincrement byte count by 2 (1 word)
+    subq    #2, %d7                    | Deincrement byte count by 2 (1 word)
     bne.s   AMDWriteSectorLoop         | Next word if not done
 
     move.w  #AMD_READ_ARRAY_CMD, (%a1) | 0xF0F0 Return to Normal Read Array mode
@@ -1113,7 +1110,7 @@ VPWSendBlockWaitForBuffer2:
 | ---------------------------------------------------------------------------
 .data
 .ascii "(c)2023 pcmhacking.net" | An Antus / Gampy collaboration
-| Mode 35 Reply Header 10 bytes + 1 alignment
+| Mode 35 Reply Header 10 bytes
 Mode35Reply:    .byte  0x6D, toolid, pcmid, 0x36, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00
 
 | Flash ID 9 bytes
@@ -1122,7 +1119,7 @@ FlashIDReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x01, 0x00, 0x00, 0x00, 0x00
 | Os ID Reply, 9 bytes
 OsIDReply:      .byte  0x6C, toolid, pcmid, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x00
 
-| Kernel ID Response, 9 bytes + 1 alignment
+| Kernel ID Response, 9 bytes
 | 4 bytes, the first 12 bits are a static ID, next 12 bits are version, 4th byte = PCM ID
 | P01/P59 = 01
 | P04     = 04
@@ -1138,7 +1135,7 @@ Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44
 | Mode36 Reply, 6 bytes - 6C F0 10 76 00 00
 Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x00
 
-| Halt Kernel Reply, 4 bytes + 1 alignment
+| Halt Kernel Reply, 4 bytes
 Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60
 
 | Erase Sector Reply, 7 bytes

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -256,7 +256,13 @@ ProcessCRCMainLoopCheck:
     move.b  #toolid, 1(%a0)            | To: Tool
     move.b  #pcmid, 2(%a0)             | From: PCM
     move.b  #0x7D, 3(%a0)              | 3D + 40 = Mode 3D, Success
-    move.l  %d0, 11(%a0)               | Move long CRC value to reply buffer
+    move.b  %d0, 14(%a0)               | Move low byte of long CRC to reply buffer
+    lsr.l   #8, %d0                    | Prepare next byte
+    move.b  %d0, 13(%a0)               | Move next byte
+    lsr.l   #8, %d0                    | Prepare next byte
+    move.b  %d0, 12(%a0)               | Move next byte
+    lsr.l   #8, %d0                    | Prepare next byte
+    move.b  %d0, 11(%a0)               | Move last byte
     move.l  #15, %d0                   | It's 15 bytes long (6C F0 10 7D 02 01 00 00 01 00 00 67 86 6E C2)
     bsr.w   VPWSend                    | Send it
     jmp     MainLoop                   | Return to MainLoop
@@ -1112,7 +1118,7 @@ OsIDReply:      .byte  0x6C, toolid, pcmid, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x00
 | P10     = 0A
 | P12     = 0C
 | E54     = 36
-KernelIDReply:  .byte  0x6C, toolid, pcmid, 0x7D, 0x00, 0x82, 0x40, 0x02, 0x00, 0xAA
+KernelIDReply:  .byte  0x6C, toolid, pcmid, 0x7D, 0x00, 0x82, 0x40, 0x02, 0x00
 
 | Mode34 Reply, 6 bytes - 6C F0 10 74 00 44, Default Success
 Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -25,7 +25,7 @@
 #if defined P12
   .equ SIM_BASE,             0xFA30
   .equ SIM_20,               (SIM_BASE + 0x20) | Lock functions
-  #else
+#else
   .equ SIM_BASE,             0xFA00
 #endif
 .equ SIM_CSBARBT,            (SIM_BASE + 0x48) | (SIM_BASE + 0x48) (FA48)
@@ -38,7 +38,7 @@
   .equ REG_FFF4C8,           0xF4C8
   .equ VPP_BIT,              2
   .equ HARDWARE_IO,          0xFA11
-  #else
+#else
   .equ VPP_BIT,              0
   .equ HARDWARE_IO,          0xE2FA
 #endif
@@ -76,15 +76,15 @@
 .equ POLYNOMIAL,         0x4C11DB7
 
 | Modes supported shared in Common-Assembly.S
-|.equ KernelID_3D00      0x00        | Moved to Common-Assembly.s
+|.equ KernelID_3D00       0x00       | Moved to Common-Assembly.s
 .equ FlashID_3D01,       0x01        | Return Flash chip ID
 .equ CRC_3D02,           0x02        | Return CRC for range
 .equ OsID_3D03,          0x03        | Return OsID
 .equ EraseSector_3D05,   0x05        | ProcessEraseSector
-|.equ Halt_20            0x20        | Moved to Common-Assembly.s
-|.equ Mode_34            0x34        | Moved to Common-Assembly.s
-.equ Mode_35,            0x35        | Send data from PCM to Tool
-|.equ Mode_36            0x36        | Moved to Common-Assembly.s
+|.equ Halt_20             0x20         | Moved to Common-Assembly.s
+|.equ Mode_34             0x34         | Moved to Common-Assembly.s
+.equ Mode_35,            0x35          | Send data from PCM to Tool
+|.equ Mode_36             0x36         | Moved to Common-Assembly.s
 
 start:
     ori     #0x700, %sr                | Disable Interrupts
@@ -362,23 +362,17 @@ ProcessEraseSector:
     clr.l   %d0                        | Start Clean
     movea.l #FlashIDReply, %a1         | Pointer to FlashIDReply buffer
 
-    move.w  7(%a1), %d1
+    move.b  5(%a1), %d1
+    lsl.l   #8, %d1
+    move.b  6(%a1), %d1
 
     | Intel
-    cmp.w #FLASH_ID_INTEL_28F400B, %d1 | 0x4471 512k
-    beq.s ProcessEraseSectorIntel      | Intel Flash Erase
-    cmp.w #FLASH_ID_INTEL_28F800B, %d1 | 0x889D 1m
-    beq.s ProcessEraseSectorIntel      | Intel Flash Erase
+    cmp.w   #INTEL_ID, %d1             | Intel manufacturer ID
+    beq.s   ProcessEraseSectorIntel    | Intel Flash Erase
 
     | AMD
-    cmp.w   #FLASH_ID_AMD_AM29F400BB, %d1 | 0x22AB 512k
-    beq.s   ProcessEraseSectorAMD         | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29F800BB, %d1 | 0x2258 1m
-    beq.s   ProcessEraseSectorAMD         | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29BL802C, %d1 | 0x2281 1m
-    beq.s   ProcessEraseSectorAMD         | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29BL162C, %d1 | 0x2203 2m
-    beq.s   ProcessEraseSectorAMD         | AMD Flash Erase
+    cmp.w   #AMD_ID, %d1               | AMD manufacturer ID
+    beq.s   ProcessEraseSectorAMD      | AMD Flash Erase
 
     move.b  #1, %d0                    | Set error
     bra.s   ProcessEraseSectorFinal    | Fail
@@ -422,20 +416,12 @@ ProcessWriteFlash:
     move.w  7(%a2), %d1                | Move Flash Chip ID to d1
 
     | Intel
-    cmp.w   #FLASH_ID_INTEL_28F400B, %d1  | 0x4471 512k
-    beq.s   ProcessWriteFlashIntel        | Intel Flash Erase
-    cmp.w   #FLASH_ID_INTEL_28F800B, %d1  | 0x889D 1m
-    beq.s   ProcessWriteFlashIntel        | Intel Flash Erase
+    cmp.w   #INTEL_ID, %d1             | Intel manufacturer ID
+    beq.s   ProcessWriteFlashIntel     | Intel glash write
 
     | AMD
-    cmp.w   #FLASH_ID_AMD_AM29F400BB, %d1 | 0x22AB 512k
-    beq.s   ProcessWriteFlashAMD          | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29F800BB, %d1 | 0x2258 1m
-    beq.s   ProcessWriteFlashAMD          | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29BL802C, %d1 | 0x2281 1m
-    beq.s   ProcessWriteFlashAMD          | AMD Flash Erase
-    cmp.w   #FLASH_ID_AMD_AM29BL162C, %d1 | 0x2203 2m
-    beq.s   ProcessWriteFlashAMD          | AMD Flash Erase
+    cmp.w   #AMD_ID, %d1               | AMD manufacturer ID
+    beq.s   ProcessWriteFlashAMD       | AMD flash write
 
     move.b  #1, %d0                    | Set error
     bra.s   ProcessWriteFlashFinal
@@ -632,7 +618,7 @@ AMDWriteSectorNotReady:
     move.w  (%a1), %d1                 | Read what was written
     cmp.w   %d3, %d1                   | Compare to what was written
     beq.s   AMDWriteSectorSuccess      | Jump for next byte if match
-    dbeq    %d2, AMDWriteSectorNotReady| Retry reading back written value
+    dbeq    %d2, AMDWriteSectorNotReady | Retry reading back written value
 
     move.w  (%a1), %d1                 | One last chance
     cmp.w   %d1, %d3                   | Compare to whats written
@@ -693,7 +679,7 @@ LongWaitWithWatchdog:
 LongWaitLoop:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
-    dbf     %d1, LongWaitLoop          | If False Decrement and Branch
+    dbf     %d1, LongWaitLoop | If False Decrement and Branch
     movem.l (%sp)+, %d5                | Restore d5
     rts
 
@@ -795,7 +781,7 @@ IntelWriteSector:
     bsr.w   IntelFlashUnlock
 
 IntelWriteSectorLoop:
-    move.w  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346)
+    move.w  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346) (Not used?)
 
     | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
     | So we make words out of bytes ...
@@ -1107,13 +1093,11 @@ VPWSendBlockWaitForBuffer2:
 | ---------------------------------------------------------------------------
 .data
 .ascii "(c)2023 pcmhacking.net" | An Antus / Gampy collaboration
-| All AA bytes are padding for alignment
-
 | Mode 35 Reply Header 10 bytes + 1 alignment
-Mode35Reply:    .byte  0x6D, toolid, pcmid, 0x36, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA
+Mode35Reply:    .byte  0x6D, toolid, pcmid, 0x36, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00
 
 | Flash ID 9 bytes
-FlashIDReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x01, 0x00, 0x00, 0x00, 0x00, 0xAA
+FlashIDReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x01, 0x00, 0x00, 0x00, 0x00
 
 | Os ID Reply, 9 bytes
 OsIDReply:      .byte  0x6C, toolid, pcmid, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x00
@@ -1135,7 +1119,7 @@ Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44
 Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x00
 
 | Halt Kernel Reply, 4 bytes + 1 alignment
-Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60, 0xAA
+Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60
 
 | Erase Sector Reply, 7 bytes
 EraseSectorReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x05, 0x00, 0x00

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -193,6 +193,7 @@ ProcessKernelID:
 ProcessOsID:
 #if defined P04
     movea.l #0x7FFFA, %a1              | Pointer to OsID location in Flash
+    |movea.l #0x3FFFA, %a1              | Pointer to OsID location in Flash (swap to this statement for 96/97 V6 support. TODO: split this out of P04 or implement the above)
 #elif defined P08
     movea.l #0x8000, %a1               | Pointer to OsID location in Flash
 #elif defined P10
@@ -334,7 +335,7 @@ ProcessFlashIDFound:
     lsl.w   #8, %d1                    | Shift left
     move.b  %d1, 5(%a0)                | Move MFG ID HI to FlashIDReply buffer
     move.b  %d0, 8(%a0)                | Move Flash ID LO to FlashIDReply buffer
-    lsr.w   #8, %d0                    | Shift left
+    lsr.w   #8, %d0                    | Shift right
     move.b  %d0, 7(%a0)                | Move Flash ID HI to FlashIDReply buffer
     move.l  #9, %d0                    | It's 9 bytes long
     bsr.w   VPWSend                    | Send it
@@ -690,7 +691,7 @@ LongWaitWithWatchdog:
 LongWaitLoop:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
-    dbf     %d1, LongWaitLoop | If False Decrement and Branch
+    dbf     %d1, LongWaitLoop          | If False Decrement and Branch
     movem.l (%sp)+, %d5                | Restore d5
     rts
 

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -1,4 +1,4 @@
-| GM '0411 Kernel for PCMHammer
+| GM VPW Kernel for PCMHammer
 | 2018-2023 Antus / PCMHacking.net
 | 2023-03-25 @21:00 Gampy <@pcmhacking.net>
 | ===========================================================================
@@ -76,15 +76,15 @@
 .equ POLYNOMIAL,         0x4C11DB7
 
 | Modes supported shared in Common-Assembly.S
-|.equ KernelID_3D00       0x3D00       | Moved to Common-Assembly.s
-.equ FlashID_3D01,       0x3D01        | Return Flash chip ID
-.equ CRC_3D02,           0x3D02        | Return CRC for range
-.equ OsID_3D03,          0x3D03        | Return OsID
-.equ EraseSector_3D05,   0x3D05        | ProcessEraseSector
-|.equ Halt_20             0x20         | Moved to Common-Assembly.s
-|.equ Mode_34             0x34         | Moved to Common-Assembly.s
-.equ Mode_35,            0x35          | Send data from PCM to Tool
-|.equ Mode_36             0x36         | Moved to Common-Assembly.s
+|.equ KernelID_3D00      0x00        | Moved to Common-Assembly.s
+.equ FlashID_3D01,       0x01        | Return Flash chip ID
+.equ CRC_3D02,           0x02        | Return CRC for range
+.equ OsID_3D03,          0x03        | Return OsID
+.equ EraseSector_3D05,   0x05        | ProcessEraseSector
+|.equ Halt_20            0x20        | Moved to Common-Assembly.s
+|.equ Mode_34            0x34        | Moved to Common-Assembly.s
+.equ Mode_35,            0x35        | Send data from PCM to Tool
+|.equ Mode_36            0x36        | Moved to Common-Assembly.s
 
 start:
     ori     #0x700, %sr                | Disable Interrupts
@@ -96,14 +96,14 @@ start:
     move.b  #0x03, (J1850_Command).l   | Flush frame except for completion code
     move.b  #0x00, (J1850_TX_FIFO).l   | Initiate transfer
 
-Wait01:
+DLCWait01:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
     move.b  (J1850_Status).l, %d0      | Get the VPW status
     andi.b  #0xE0, %d0                 | Mask Receive FIFO Status Field (RFS) register 1110 0000
     cmpi.b  #0xE0, %d0                 | Check for "completion code only, at head of buffer" message 1110 0000
-    bne.b   Wait01                     | Not ready? wait and retry
-    move.b  (J1850_RX_FIFO).l, %d0     | Strip off the completion code
+    bne.b   DLCWait01                  | Not ready? wait and retry
+    move.b  (J1850_RX_FIFO).l, %d0     | Flush the completion code
 
 #if defined P12
     movea.l #Mode36Reply, %a0          | Reply Success to mode 3680, only P12 needs this.
@@ -112,30 +112,25 @@ Wait01:
     bsr.w   WasteTime                  | Twiddle thumbs
 #endif
 
-    movea.l #Ping, %a0                 | Reply Success to mode 3680, only P12 needs this.
-    move.l  #6, %d0                    | It's 6 bytes long
-    bsr.w   VPWSend                    | Send message
-
-    movea.l #Ping, %a0                 | Reply Success to mode 3680, only P12 needs this.
-    move.l  #6, %d0                    | It's 6 bytes long
-    bsr.w   VPWSend                    | Send message
-
 MainLoop:
     movea.l #MessageBuffer, %a0        | Pointer to MessageBuffer buffer
-    clr.w   3(%a0)                     | Clear last command, prevent repeating it
+    clr.b   3(%a0)                     | Clear last command, prevent repeating it
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   VPWReceive                 | Wait for and read next packet
     bsr.w   WasteTime                  | Twiddle thumbs
-    cmpi.w  #KernelID_3D00, 3(%a0)     | Is it mode 0x3D 00 Get Kernel ID (non-standard extension)
+    cmpi.b  #KernelMode, 3(%a0)        | Is it mode 0x3D? (Kernel extension)
+    bne.b   MainStd                    | Jump to standard functions
+    cmpi.b  #KernelID_3D00, 4(%a0)     | Is it mode 0x3D 00 Get Kernel ID (non-standard extension)
     beq.w   ProcessKernelID            | Process it
-    cmpi.w  #FlashID_3D01, 3(%a0)      | Is it mode 0x3D 01 Get Flash Chip ID (non-standard extension)
+    cmpi.b  #FlashID_3D01, 4(%a0)      | Is it mode 0x3D 01 Get Flash Chip ID (non-standard extension)
     beq.w   ProcessFlashID             | Process it
-    cmpi.w  #CRC_3D02, 3(%a0)          | Is it mode 0x3D 02 Get Flash Sector CRC (non-standard extension)
+    cmpi.b  #CRC_3D02, 4(%a0)          | Is it mode 0x3D 02 Get Flash Sector CRC (non-standard extension)
     beq.w   ProcessCRC                 | Process it
-    cmpi.w  #OsID_3D03, 3(%a0)         | Is it mode 0x3D 03 Get Os ID (non-standard extension)
+    cmpi.b  #OsID_3D03, 4(%a0)         | Is it mode 0x3D 03 Get Os ID (non-standard extension)
     beq.w   ProcessOsID                | Process it
-    cmpi.w  #EraseSector_3D05, 3(%a0)  | Is it mode 0x3D 05 Erase Flash Sector (non-standard extension)
+    cmpi.b  #EraseSector_3D05, 4(%a0)  | Is it mode 0x3D 05 Erase Flash Sector (non-standard extension)
     beq.w   ProcessEraseSector         | Process it
+MainStd:
     cmpi.b  #Mode_34, 3(%a0)           | Is it mode 0x34 (Tool asking PCM, ok to send X bytes to address)
     beq.w   ProcessMode34              | Process it
     cmpi.b  #Mode_35, 3(%a0)           | Is it mode 0x35 (Tool asking PCM to send data from Flash)
@@ -329,8 +324,12 @@ ProcessFlashIDFound:
     move.w  #0x1060, (SIM_CSOR0).w     | 0xFA4E
 #endif
     movea.l #FlashIDReply, %a0         | Pointer to FlashIDReply buffer
-    move.w  %d1, 5(%a0)                | Move MFG ID to FlashIDReply buffer
-    move.w  %d0, 7(%a0)                | Move Flash ID to FlashIDReply buffer
+    move.b  %d1, 6(%a0)                | Move MFG ID LO to FlashIDReply buffer
+    lsl.w   #8, %d1                    | Shift left
+    move.b  %d1, 5(%a0)                | Move MFG ID HI to FlashIDReply buffer
+    move.b  %d0, 8(%a0)                | Move Flash ID LO to FlashIDReply buffer
+    lsr.w   #8, %d0                    | Shift left
+    move.b  %d0, 7(%a0)                | Move Flash ID HI to FlashIDReply buffer
     move.l  #9, %d0                    | It's 9 bytes long
     bsr.w   VPWSend                    | Send it
     jmp     MainLoop
@@ -613,7 +612,7 @@ AMDWriteSector:
     lea     AMD_CMD_ADDRESS_B, %a3     | (0x0554) Pointer to the command address
 
 AMDWriteSectorLoop:
-    move.l  #2346, %d2                 | FlashNotReady Loop Timeout index
+    move.w  #2346, %d2                 | FlashNotReady Loop Timeout index
 
     | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
     | So we make words out of bytes ...
@@ -688,13 +687,9 @@ IntelFlashUnlock:
     bsr.w   LongWaitWithWatchdog
     rts
 
-ShortWaitWithWatchdog:
-    movem.l %d5, -(%sp)                | Save d5
-    move.l  #0x5, %d1                  | 5 loops
-    bra.s   LongWaitLoop               | Re-use the long wait loop
 LongWaitWithWatchdog:
     movem.l %d5, -(%sp)                | Save d5
-    move.l  #0x8000, %d1               | 32768 loops
+    move.w  #0x8000, %d1               | 32768 loops
 LongWaitLoop:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
@@ -747,7 +742,6 @@ IntelFlashLock:
 |   d2 - Loop Index
 |
 IntelEraseSector:
-    clr.l   %d1                           | clear scratch space
     bsr.w   IntelFlashUnlock
 
     move.w  #CLEAR_STATUS_REGISTER, (%a0) | 0x5050 Clear Status register
@@ -801,7 +795,7 @@ IntelWriteSector:
     bsr.w   IntelFlashUnlock
 
 IntelWriteSectorLoop:
-    move.l  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346)
+    move.w  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346)
 
     | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
     | So we make words out of bytes ...
@@ -1109,23 +1103,9 @@ VPWSendBlockWaitForBuffer2:
     move.b  #0xC, (J1850_Command).l    | BTAD ...0 11.. "Load as last byte of transmit data"
     move.b  %d1, (J1850_TX_FIFO).l     | Move the Second checksum byte  to the TX FIFO
     rts
-    
-HaltNoReboot:
-    bsr.w   ResetWatchdog
-    bra.s   HaltNoReboot
 
 | ---------------------------------------------------------------------------
 .data
-
-| This 0x0D byte is required (any single byte works), ALL data must be knocked off word boundries, this causes a hella nightmare
-|  when the desire is to work with words, we should be keeping everything word based (i.e. according to hoyle).
-| It has to be before the last data declaration.
-|
-| If MessageBuffer is on a valid word boundry, VPWReceive fails, it only works when it's misaligned to word boundries.
-| I think it needs to get two bytes, make a word, then add it to MessageBuffer by Word, or shift the bytes left by one!
-| Every attempt I've made to accomplish this has failed ... Purely due to my lack of knowledge of the DLC!
-| Alignment is simple ... Remove this 0x0D and it is aligned, however VPWReceive will fail.
-
 .ascii "(c)2023 pcmhacking.net" | An Antus / Gampy collaboration
 | All AA bytes are padding for alignment
 
@@ -1160,10 +1140,6 @@ Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60, 0xAA
 | Erase Sector Reply, 7 bytes
 EraseSectorReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x05, 0x00, 0x00
 
-|used for debugging
-Ping:   .byte  0x6C, 0xFF, pcmid, 0x3F, 0x01, 0x02
-
-.byte 0xAA
 | Global buffer, it's at the end and it's not transported, thus length is irrelevant!
   .globl   MessageBuffer
   .section .kerneldata, "aw", @progbits | Kernel data section, how it's excluded from transportation.

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -112,6 +112,14 @@ Wait01:
     bsr.w   WasteTime                  | Twiddle thumbs
 #endif
 
+    movea.l #Ping, %a0                 | Reply Success to mode 3680, only P12 needs this.
+    move.l  #6, %d0                    | It's 6 bytes long
+    bsr.w   VPWSend                    | Send message
+
+    movea.l #Ping, %a0                 | Reply Success to mode 3680, only P12 needs this.
+    move.l  #6, %d0                    | It's 6 bytes long
+    bsr.w   VPWSend                    | Send message
+
 MainLoop:
     movea.l #MessageBuffer, %a0        | Pointer to MessageBuffer buffer
     clr.w   3(%a0)                     | Clear last command, prevent repeating it
@@ -605,7 +613,7 @@ AMDWriteSector:
     lea     AMD_CMD_ADDRESS_B, %a3     | (0x0554) Pointer to the command address
 
 AMDWriteSectorLoop:
-    move.w  #2346, %d2                 | FlashNotReady Loop Timeout index
+    move.l  #2346, %d2                 | FlashNotReady Loop Timeout index
 
     | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
     | So we make words out of bytes ...
@@ -625,7 +633,7 @@ AMDWriteSectorNotReady:
     move.w  (%a1), %d1                 | Read what was written
     cmp.w   %d3, %d1                   | Compare to what was written
     beq.s   AMDWriteSectorSuccess      | Jump for next byte if match
-    dbeq    %d2, AMDWriteSectorNotReady | Retry reading back written value
+    dbeq    %d2, AMDWriteSectorNotReady| Retry reading back written value
 
     move.w  (%a1), %d1                 | One last chance
     cmp.w   %d1, %d3                   | Compare to whats written
@@ -680,13 +688,17 @@ IntelFlashUnlock:
     bsr.w   LongWaitWithWatchdog
     rts
 
+ShortWaitWithWatchdog:
+    movem.l %d5, -(%sp)                | Save d5
+    move.l  #0x5, %d1                  | 5 loops
+    bra.s   LongWaitLoop               | Re-use the long wait loop
 LongWaitWithWatchdog:
     movem.l %d5, -(%sp)                | Save d5
-    move.w  #0x8000, %d1               | 32768 loops
+    move.l  #0x8000, %d1               | 32768 loops
 LongWaitLoop:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
-    dbf     %d1, LongWaitLoop | If False Decrement and Branch
+    dbf     %d1, LongWaitLoop          | If False Decrement and Branch
     movem.l (%sp)+, %d5                | Restore d5
     rts
 
@@ -789,7 +801,7 @@ IntelWriteSector:
     bsr.w   IntelFlashUnlock
 
 IntelWriteSectorLoop:
-    move.w  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346)
+    move.l  #0x92A, %d2                | FlashNotReady Loop Timeout index (2346)
 
     | We cannot write by bytes, we must write by word, all data has been forced off word boundries, see NOTE in data section at EOF
     | So we make words out of bytes ...
@@ -1097,6 +1109,10 @@ VPWSendBlockWaitForBuffer2:
     move.b  #0xC, (J1850_Command).l    | BTAD ...0 11.. "Load as last byte of transmit data"
     move.b  %d1, (J1850_TX_FIFO).l     | Move the Second checksum byte  to the TX FIFO
     rts
+    
+HaltNoReboot:
+    bsr.w   ResetWatchdog
+    bra.s   HaltNoReboot
 
 | ---------------------------------------------------------------------------
 .data
@@ -1143,6 +1159,9 @@ Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60, 0xAA
 
 | Erase Sector Reply, 7 bytes
 EraseSectorReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x05, 0x00, 0x00
+
+|used for debugging
+Ping:   .byte  0x6C, 0xFF, pcmid, 0x3F, 0x01, 0x02
 
 .byte 0xAA
 | Global buffer, it's at the end and it's not transported, thus length is irrelevant!

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -735,6 +735,7 @@ IntelFlashLock:
 |   d2 - Loop Index
 |
 IntelEraseSector:
+    clr.l   %d1                           | clear scratch space
     bsr.w   IntelFlashUnlock
 
     move.w  #CLEAR_STATUS_REGISTER, (%a0) | 0x5050 Clear Status register

--- a/Kernels/Kernel.S
+++ b/Kernels/Kernel.S
@@ -11,10 +11,6 @@
 
 |
 | NOTICE!
-| The full Kernel is to big to fit on the P04 & P08, so I have "#if !defined P04" and "#if !defined P08" out Write capabilities to maintain read compatibility with PCMHammer.
-| There are 3 "#if !defined P04" and 3 "#if !defined P08" below, plus their matching #else and #endif.
-|
-| It's ugly, it's what I had to do to release this code ...
 |
 | Even with just the required elements for writing, it is tough to get a stable Kernel on the P04, especially Intel based units (SvN:9380717, HdW:9357440
 | It can be done, but PCMHammer also needs to be rewritten to work with 3 kernels, 1. Read Kernel, 2. AMD Write Kernel, 3. Intel Write Kernel.
@@ -29,14 +25,24 @@
 #if defined P12
   .equ SIM_BASE,             0xFA30
   .equ SIM_20,               (SIM_BASE + 0x20) | Lock functions
-#else
+  #else
   .equ SIM_BASE,             0xFA00
 #endif
 .equ SIM_CSBARBT,            (SIM_BASE + 0x48) | (SIM_BASE + 0x48) (FA48)
 .equ SIM_CSORBT,             (SIM_BASE + 0x4A) | (SIM_BASE + 0x4A) (FA4A)
 .equ SIM_CSBAR0,             (SIM_BASE + 0x4C) | (SIM_BASE + 0x4C) (FA4C)
 .equ SIM_CSOR0,              (SIM_BASE + 0x4E) | (SIM_BASE + 0x4E) (FA4E)
-|
+
+#if defined P08
+  .equ REG_FFF408,           0xF408
+  .equ REG_FFF4C8,           0xF4C8
+  .equ VPP_BIT,              2
+  .equ HARDWARE_IO,          0xFA11
+  #else
+  .equ VPP_BIT,              0
+  .equ HARDWARE_IO,          0xE2FA
+#endif
+
 .equ READ_ARRAY_CMD,         0xFFFF    | Intel
 .equ ERASE_RESUME_CONFIRM,   0xD0D0    | Intel
 .equ AMD_PROGRAM_CMD,        0xA0A0    | Amd
@@ -70,18 +76,23 @@
 .equ POLYNOMIAL,         0x4C11DB7
 
 | Modes supported shared in Common-Assembly.S
-|.equ KernelID_3D00       0x3D00        | Moved to Common-Assembly.s
+|.equ KernelID_3D00       0x3D00       | Moved to Common-Assembly.s
 .equ FlashID_3D01,       0x3D01        | Return Flash chip ID
 .equ CRC_3D02,           0x3D02        | Return CRC for range
 .equ OsID_3D03,          0x3D03        | Return OsID
 .equ EraseSector_3D05,   0x3D05        | ProcessEraseSector
-|.equ Halt_20             0x20          | Moved to Common-Assembly.s
-|.equ Mode_34             0x34          | Moved to Common-Assembly.s
+|.equ Halt_20             0x20         | Moved to Common-Assembly.s
+|.equ Mode_34             0x34         | Moved to Common-Assembly.s
 .equ Mode_35,            0x35          | Send data from PCM to Tool
-|.equ Mode_36             0x36          | Moved to Common-Assembly.s
+|.equ Mode_36             0x36         | Moved to Common-Assembly.s
 
 start:
     ori     #0x700, %sr                | Disable Interrupts
+
+#if defined P08
+    movea.w #0xB800, %sp               | P08: Relocate the stack
+#endif
+
     move.b  #0x03, (J1850_Command).l   | Flush frame except for completion code
     move.b  #0x00, (J1850_TX_FIFO).l   | Initiate transfer
 
@@ -333,8 +344,6 @@ ProcessFlashIDFound:
 |   d1 - Scratch
 |
 ProcessEraseSector:
-#if !defined P04       // Reduce size for P04 & P08 read only
-#if !defined P08       // Reduce size for P04 & P08 read only
     clr.l   %d1                        | Start Clean
     or.b    MessageBuffer + 5, %d1     | First address byte
     lsl.l   #8, %d1                    | Logical Shift Left
@@ -380,8 +389,6 @@ ProcessEraseSectorFinal:
     move.b  %d0, 5(%a0)                | Move error value to EraseSectorReply buffer
     move.l  #7, %d0                    | PCMHammer returns 7 bytes, 6C F0 10 7D 05 00 00, last two are Status and Error?, why two??
     bsr.w   VPWSend                    | Send it!
-#endif                                 // Reduce size for P04 & P08 read only
-#endif                                 // Reduce size for P04 & P08 read only
     jmp     MainLoop
 
 | =============== S U B R O U T I N E =======================================
@@ -403,8 +410,6 @@ ProcessEraseSectorFinal:
 |   a2 - Address FlashIDReply
 |   d1 - Scratch
 |
-#if !defined P04                       // Reduce size for P04 & P08 read only
-#if !defined P08                       // Reduce size for P04 & P08 read only
 ProcessWriteFlash:
     movea.l #FlashIDReply, %a2         | Pointer to FlashIDReply buffer
     move.w  7(%a2), %d1                | Move Flash Chip ID to d1
@@ -655,39 +660,28 @@ AMDWriteSectorFinal:
 |   d1 - Scratch
 |
 IntelFlashUnlock:
+#if defined P08
+    move.w #0x0F, (REG_FFF408).w       | P08 Hardware Setup
+    move.w #0x05, (REG_FFF4C8).w       | P08 Hardware Setup
+#endif
     move.w  #0x0007, (SIM_CSBARBT).w   | $FFFFFA48
     move.w  #0x6820, (SIM_CSORBT).w    | $FFFFFA4A
     move.w  #0x0007, (SIM_CSBAR0).w    | $FFFFFA4C
     | Unlock
     move.w  #0x7060, (SIM_CSOR0).w     | $FFFFFA4E
-
     | Enable +12v Vpp
-    move.w  (0xE2FA).w, %d1            | Move Vpp Latch Address value to d1
-    bset    #0, %d1                    | Set Vpp Latch Bit
-    move.w  %d1, (0xE2FA).w            | Move modified value back to Latch Address
-    |move.w  (HARDWARE_IO), %d1         | Move Vpp Latch Address value to d1
-    |bset    #VPP_BIT, %d1              | Set Vpp Latch Bit
-    |move.w  %d1, (HARDWARE_IO)         | Move modified value back to Latch Address
-    |bset    #VPP_BIT, (HARDWARE_IO)    |  Set Vpp Latch Bit
+    bset    #VPP_BIT, (HARDWARE_IO).w  | Set Vpp
+    bsr.w   LongWaitWithWatchdog
+    rts
 
-|LongWaitWithWatchdog:
-| Only place it's used, saves ~12 bytes, if needed elsewhere, sub it, change d1 to d5, uncomment movem.l lines
-  |  movem.l %d5, -(%sp)                | Save d5
-    move.w  #0x2710, %d1               | 10,000 loops
-IntelFlashUnlockLongWaitLoop:
+LongWaitWithWatchdog:
+    movem.l %d5, -(%sp)                | Save d5
+    move.w  #0x8000, %d1               | 32768 loops
+LongWaitLoop:
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   WasteTime                  | Twiddle thumbs
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    bsr.w   WasteTime
-    dbf     %d1, IntelFlashUnlockLongWaitLoop | If False Decrement and Branch
-  |  movem.l (%sp)+, %d5                | Restore d5
+    dbf     %d1, LongWaitLoop | If False Decrement and Branch
+    movem.l (%sp)+, %d5                | Restore d5
     rts
 
 | =============== S U B R O U T I N E =======================================
@@ -707,13 +701,9 @@ IntelFlashLock:
     | Lock
     move.w  #0x1060, (SIM_CSOR0).w     | $FFFFFA4E
     | Disable +12v Vpp
-    move.w  (0xE2FA).w, %d1              | Move Vpp Latch Address value to d1
-    bclr    #0, %d1                    | Set Vpp Latch Bit
-    move.w  %d1, (0xE2FA).w              | Move modified value back to Latch Address
-    |move.w  (HARDWARE_IO), %d1         | Move Vpp Latch Address value to d1
-    |bclr    #VPP_BIT, %d1              | Set Vpp Latch Bit
-    |move.w  %d1, (HARDWARE_IO)         | Move modified value back to Latch Address
-    |bclr    #VPP_BIT, (HARDWARE_IO)    | Clear Vpp Latch Bit - This technique is unsupported, leave as reminder!
+    bclr    #VPP_BIT, (HARDWARE_IO).w  | Clear Vpp
+    bsr.w   LongWaitWithWatchdog
+
     rts
 
 | =============== S U B R O U T I N E =======================================
@@ -739,28 +729,27 @@ IntelEraseSector:
     move.w  #CLEAR_STATUS_REGISTER, (%a0) | 0x5050 Clear Status register
     move.w  #INTEL_ERASE_CMD, (%a0)       | 0x2020 Command Erase
     move.w  #ERASE_RESUME_CONFIRM, (%a0)  | 0xD0D0 Confirm Command Erase
-    move.w  #READ_STATUS_REGISTER, (%a0)  | 0x7070 Read Status Register
-
-    move.l  #0x320000, %d2             | Erase Loop Timeout index
+    move.l  #0x320000, %d2                | Erase Loop Timeout index
 
 IntelEraseSectorNotReady:
-    bsr.w   ResetWatchdog              | Scratch the dog
-    move.w  (%a0), %d1                 | Move Status to d1
-    btst    #0x007, %d1                | Test Status
-    bne.s   IntelEraseSectorReady      | Status Success - Jump to IntelEraseSectorReady
-    subq.l  #1, %d2                    | Decrement index
-    bne.s   IntelEraseSectorNotReady   | Fail Status Check Test again
+    bsr.w   LongWaitWithWatchdog
+    move.w  #READ_STATUS_REGISTER, (%a0)  | 0x7070 Read Status Register
+    move.w  (%a0), %d1                    | Move Status to d1
+    btst    #0x007, %d1                   | Test Status
+    bne.s   IntelEraseSectorReady         | Status Success - Jump to IntelEraseSectorReady
+    subq.l  #1, %d2                       | Decrement index
+    bne.s   IntelEraseSectorNotReady      | Fail Status Check Test again
 
 IntelEraseSectorReady:
-    clr.l   %d0                        | Set Success (if Status passes)
-    andi.w  #0x0E8, %d1                | Mask 1110 1000
-    cmp.w   #0x080, %d1                | Check status
-    beq.s   IntelEraseSectorDone       | Pass ?
-    move.b  #1, %d0                    | Set Failure
+    clr.l   %d0                           | Set Success (if Status passes)
+    andi.w  #0x0E8, %d1                   | Mask 1110 1000
+    cmp.w   #0x080, %d1                   | Check status
+    beq.s   IntelEraseSectorDone          | Pass ?
+    move.b  #1, %d0                       | Set Failure
 
 IntelEraseSectorDone:
-    move.w    #READ_ARRAY_CMD, (%a0)     | 0xFFFF Return to Normal Read Array mode
-    move.w    #READ_ARRAY_CMD, (%a0)     | 0xFFFF Return to Normal Read Array mode
+    move.w    #READ_ARRAY_CMD, (%a0)      | 0xFFFF Return to Normal Read Array mode
+    move.w    #READ_ARRAY_CMD, (%a0)      | 0xFFFF Return to Normal Read Array mode
 
     bsr.w   IntelFlashLock
     rts
@@ -828,9 +817,6 @@ IntelWriteSectorFinal:
     bsr.w   IntelFlashLock
     rts
 
-#endif                                 // Reduce size for P04 & P08 read only
-#endif                                 // Reduce size for P04 & P08 read only
-
 | =============== S U B R O U T I N E =======================================
 ProcessMode34:
 | TODO: Add rejections
@@ -882,8 +868,6 @@ ProcessMode35:
 |   d4
 |
 ProcessMode36:
-#if !defined P04                       // Reduce size for P04 & P08 read only
-#if !defined P08                       // Reduce size for P04 & P08 read only
     clr.l   %d0                        | Clear for Target Address
     movea.l #MessageBuffer + 10, %a0   | Pointer to start of data
     or.b    MessageBuffer + 7, %d0     | First address byte
@@ -948,12 +932,6 @@ ProcessMode36ResponseOK:
     cmpi.b  #0x80, %d4                 | Test for Execute
     bne.w   MainLoop                   | If not executing return to MainLoop
     jmp     (%a2)                      | Execute the payload
-#else                                  // Reduce size for P04 & P08 read only
-    jmp     MainLoop                   |  Reduce size for P04 & P08 read only
-#endif                                 // Reduce size for P04 & P08 read only
-#else                                  // Reduce size for P04 & P08 read only
-    jmp     MainLoop                   |  Reduce size for P04 & P08 read only
-#endif                                 // Reduce size for P04 & P08 read only
 
 | =============== S U B R O U T I N E =======================================
 WaitForTXFIFO:
@@ -982,7 +960,7 @@ VPWSendNextByte:
     move.b  (%a0)+, (J1850_TX_FIFO).l  | Drop the last byte in TX FIFO
     bsr.w   WasteTime                  | Twiddle thumbs
     move.b  #0x03, (J1850_Command).l   | Flush buffer
-    move.b  #0x00, (J1850_TX_FIFO).l   | Needed for flush buffer?
+    move.b  #0x00, (J1850_TX_FIFO).l   | Completion byte
 
 VPWSendWaitForFlush:
     bsr.w   ResetWatchdog              | Scratch the dog
@@ -1119,19 +1097,18 @@ VPWSendBlockWaitForBuffer2:
 | I think it needs to get two bytes, make a word, then add it to MessageBuffer by Word, or shift the bytes left by one!
 | Every attempt I've made to accomplish this has failed ... Purely due to my lack of knowledge of the DLC!
 | Alignment is simple ... Remove this 0x0D and it is aligned, however VPWReceive will fail.
-.byte  0x0D
 
 .ascii "(c)2023 pcmhacking.net" | An Antus / Gampy collaboration
 | All AA bytes are padding for alignment
 
-| Mode 35 Reply Header 10 bytes
-Mode35Reply:    .byte  0x6D, toolid, pcmid, 0x36, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00
+| Mode 35 Reply Header 10 bytes + 1 alignment
+Mode35Reply:    .byte  0x6D, toolid, pcmid, 0x36, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xAA
 
-| Flash ID 9 bytes + 1 alignment
+| Flash ID 9 bytes
 FlashIDReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x01, 0x00, 0x00, 0x00, 0x00, 0xAA
 
-| Os ID Reply, 9 bytes + 1 alignment
-OsIDReply:      .byte  0x6C, toolid, pcmid, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x00, 0xAA
+| Os ID Reply, 9 bytes
+OsIDReply:      .byte  0x6C, toolid, pcmid, 0x7D, 0x03, 0x00, 0x00, 0x00, 0x00
 
 | Kernel ID Response, 9 bytes + 1 alignment
 | 4 bytes, the first 12 bits are a static ID, next 12 bits are version, 4th byte = PCM ID
@@ -1149,12 +1126,13 @@ Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44
 | Mode36 Reply, 6 bytes - 6C F0 10 76 00 00
 Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x00
 
-| Halt Kernel Reply, 4 bytes
-Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60
+| Halt Kernel Reply, 4 bytes + 1 alignment
+Mode60Reply:    .byte  0x6C, toolid, pcmid, 0x60, 0xAA
 
-| Erase Sector Reply, 7 bytes + 1 alignment
-EraseSectorReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x05, 0x00, 0x00, 0xAA
+| Erase Sector Reply, 7 bytes
+EraseSectorReply:   .byte  0x6C, toolid, pcmid, 0x7D, 0x05, 0x00, 0x00
 
+.byte 0xAA
 | Global buffer, it's at the end and it's not transported, thus length is irrelevant!
   .globl   MessageBuffer
   .section .kerneldata, "aw", @progbits | Kernel data section, how it's excluded from transportation.

--- a/Kernels/Loader.S
+++ b/Kernels/Loader.S
@@ -22,6 +22,10 @@
 start:
     ori     #0x700, %sr                | Disable Interrupts
 
+#if defined P04
+    movea.l #0xFFA000, %sp             | P04: Relocate the stack
+#endif
+
 #if defined P12
     movea.l #Mode36Reply, %a0          | Reply Success to mode 3680, only P12 needs this.
     move.l  #6, %d0                    | It's 6 bytes long
@@ -271,7 +275,7 @@ KernelIDReply:  .byte  0x6C, toolid, pcmid, 0x7D, 0x00, 0x69, 0x00, 0x01, 0x00, 
 Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44
 
 | Mode36 Reply, 6 bytes - 6C F0 10 76 00 00
-Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x00
+Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x01
 
 | Halt Kernel Reply, 4 bytes
 Mode60Reply:   .byte  0x6C, toolid, pcmid, 0x60

--- a/Kernels/Loader.S
+++ b/Kernels/Loader.S
@@ -24,6 +24,8 @@ start:
 
 #if defined P04
     movea.l #0xFFA000, %sp             | P04: Relocate the stack
+#elif defined P08
+    movea.w #0xB800, %sp               | P08: Relocate the stack
 #endif
 
 #if defined P12
@@ -35,12 +37,15 @@ start:
 
 MainLoop:
     movea.l #MessageBuffer, %a0        | Pointer to MessageBuffer buffer
-    clr.w   3(%a0)                     | Clear last command, prevent repeating it
+    clr.b   3(%a0)                     | Clear last command, prevent repeating it
     bsr.w   ResetWatchdog              | Scratch the dog
     bsr.w   VPWReceive                 | Wait for and read next packet
     bsr.w   WasteTime                  | Twiddle thumbs
-    cmpi.w  #KernelID_3D00, 3(%a0)     | Is it mode 0x3D 00 Get Kernel ID (non-standard extension)
+    cmpi.b  #KernelMode, 3(%a0)        | Is it mode 0x3D? (Kernel extension)
+    bne.b   MainStd                    | Jump to standard functions
+    cmpi.b  #KernelID_3D00, 4(%a0)     | Is it mode 0x3D 00 Get Kernel ID (non-standard extension)
     beq.w   ProcessKernelID            | Process it
+MainStd:
     cmpi.b  #Mode_34, 3(%a0)           | Is it mode 0x34 (Tool asking PCM, ok to send X bytes to address)
     beq.w   ProcessMode34              | Process it
     cmpi.b  #Mode_36, 3(%a0)           | Is it mode 0x36 (Tool sending data to write, either to RAM or Flash)
@@ -275,7 +280,7 @@ KernelIDReply:  .byte  0x6C, toolid, pcmid, 0x7D, 0x00, 0x69, 0x00, 0x01, 0x00, 
 Mode34Reply:    .byte  0x6C, toolid, pcmid, 0x74, 0x00, 0x44
 
 | Mode36 Reply, 6 bytes - 6C F0 10 76 00 00
-Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x01
+Mode36Reply:    .byte  0x6C, toolid, pcmid, 0x76, 0x00, 0x00
 
 | Halt Kernel Reply, 4 bytes
 Mode60Reply:   .byte  0x6C, toolid, pcmid, 0x60

--- a/Kernels/Loader.S
+++ b/Kernels/Loader.S
@@ -14,7 +14,8 @@
 #include "Common-Assembly.h"
 
 | Modes supported shared in Common-Assembly.S
-|.equ KernelID_3D00       0x3D00        | Moved to Common-Assembly.s
+|.equ KernelMode,         0x3D          | Mode for Kernel functions
+|.equ KernelID_3D00       0x00          | Moved to Common-Assembly.s
 |.equ Halt_20             0x20          | Moved to Common-Assembly.s
 |.equ Mode_34             0x34          | Moved to Common-Assembly.s
 |.equ Mode_36             0x36          | Moved to Common-Assembly.s
@@ -23,12 +24,10 @@ start:
     ori     #0x700, %sr                | Disable Interrupts
 
 #if defined P04
-    movea.l #0xFFA000, %sp             | P04: Relocate the stack
+    movea.w #0xA000, %sp               | P04: Relocate the stack
 #elif defined P08
     movea.w #0xB800, %sp               | P08: Relocate the stack
-#endif
-
-#if defined P12
+#elif defined P12
     movea.l #Mode36Reply, %a0          | Reply Success to mode 3680, only P12 needs this.
     move.l  #6, %d0                    | It's 6 bytes long
     bsr.w   VPWSend                    | Send message
@@ -42,7 +41,7 @@ MainLoop:
     bsr.w   VPWReceive                 | Wait for and read next packet
     bsr.w   WasteTime                  | Twiddle thumbs
     cmpi.b  #KernelMode, 3(%a0)        | Is it mode 0x3D? (Kernel extension)
-    bne.b   MainStd                    | Jump to standard functions
+    bne.b   MainStd               
     cmpi.b  #KernelID_3D00, 4(%a0)     | Is it mode 0x3D 00 Get Kernel ID (non-standard extension)
     beq.w   ProcessKernelID            | Process it
 MainStd:


### PR DESCRIPTION
Enables writing to a P08 PCM.

Tested with AVT on P08 only so far.

P01, P59, P10, P12, P12a need to be tested for regressions as the timing loop when enabling Vpp for intel has changed.

P08 OSID Database needs to be added before release, this is flash functionality only.