### PR TITLE
Parameter id duplication loading fix

### DIFF
--- a/Apps/PcmHammer/PcmHammer.csproj
+++ b/Apps/PcmHammer/PcmHammer.csproj
@@ -36,7 +36,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\a\AppData\Local\Temp\vs6362.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\pmcqu\AppData\Local\Temp\vs70D5.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -46,7 +46,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\a\AppData\Local\Temp\vs6362.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\pmcqu\AppData\Local\Temp\vs70D5.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>0411_256px.ico</ApplicationIcon>

--- a/Apps/PcmHammer/PcmHammer.csproj
+++ b/Apps/PcmHammer/PcmHammer.csproj
@@ -36,7 +36,7 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\pmcqu\AppData\Local\Temp\vs70D5.tmp\Debug\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\a\AppData\Local\Temp\vs6362.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -46,7 +46,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\pmcqu\AppData\Local\Temp\vs70D5.tmp\Release\</IntermediateOutputPath>
+    <IntermediateOutputPath>C:\Users\a\AppData\Local\Temp\vs6362.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>0411_256px.ico</ApplicationIcon>

--- a/Apps/PcmLibrary/Devices/MockDevice.cs
+++ b/Apps/PcmLibrary/Devices/MockDevice.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PcmHacking
@@ -58,6 +59,8 @@ namespace PcmHacking
         /// </summary>
         public override Task<bool> SendMessage(Message message)
         {
+            Thread.Sleep(100);
+
             StringBuilder builder = new StringBuilder();
             this.Logger.AddDebugMessage("Sending message " + message.GetBytes().ToHex());
             this.port.Send(message.GetBytes());
@@ -70,6 +73,8 @@ namespace PcmHacking
         /// <returns></returns>
         protected async override Task Receive()
         {
+            Thread.Sleep(100);
+
             //List<byte> incoming = new List<byte>(5000);
             byte[] incoming = new byte[5000];
             int count = await this.port.Receive(incoming, 0, incoming.Length);
@@ -91,6 +96,8 @@ namespace PcmHacking
         /// </remarks>
         protected override Task<bool> SetVpwSpeedInternal(VpwSpeed newSpeed)
         {
+            Thread.Sleep(100);
+
             if (newSpeed == VpwSpeed.Standard)
             {
                 this.Logger.AddDebugMessage("Setting VPW 1X");

--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PcmHacking
@@ -210,13 +211,22 @@ namespace PcmHacking
             // Wait for bytes to arrive...
             while (sw.ElapsedMilliseconds < timeout)
             {
-                if (await this.Port.GetReceiveQueueSize() > TempCount)
+                var rqSize = await this.Port.GetReceiveQueueSize();
+
+                if (rqSize > TempCount)
                 {
-                    TempCount = await this.Port.GetReceiveQueueSize();
+                    TempCount = rqSize;
                     sw.Restart();
                 }
-                if (await this.Port.GetReceiveQueueSize() >= NumBytes) { return true; }
+
+                if (rqSize >= NumBytes) 
+                {
+                    return true;
+                }
+
+                Thread.Sleep(1);
             }
+
             return false;
         }
 

--- a/Apps/PcmLibrary/Logging/LogProfileReader.cs
+++ b/Apps/PcmLibrary/Logging/LogProfileReader.cs
@@ -55,8 +55,9 @@ namespace PcmHacking
                 foreach (XElement parameterElement in container.Elements("PidParameter"))
                 {
                     string id = parameterElement.Attribute("id").Value;
+                    string name = parameterElement.Attribute("name")?.Value;
                     string units = parameterElement.Attribute("units").Value;
-                    this.AddPidParameter(id, units);
+                    this.AddPidParameter(id, name, units);
                 }
             }
         }
@@ -69,8 +70,9 @@ namespace PcmHacking
                 foreach (XElement parameterElement in container.Elements("RamParameter"))
                 {
                     string id = parameterElement.Attribute("id").Value;
+                    string name = parameterElement.Attribute("name")?.Value;
                     string units = parameterElement.Attribute("units").Value;
-                    this.AddRamParameter(id, units);
+                    this.AddRamParameter(id, name, units);
                 }
             }
         }
@@ -83,16 +85,18 @@ namespace PcmHacking
                 foreach (XElement parameterElement in container.Elements("MathParameter"))
                 {
                     string id = parameterElement.Attribute("id").Value;
+                    string name = parameterElement.Attribute("name")?.Value;
                     string units = parameterElement.Attribute("units").Value;
-                    this.AddMathParameter(id, units);
+                    this.AddMathParameter(id, name, units);
                 }
             }
         }
 
-        private void AddPidParameter(string id, string units)
+        private void AddPidParameter(string id, string name, string units)
         {
             PidParameter parameter;
-            if (!this.database.PidParameters.TryGetParameter(id, out parameter))
+
+            if (!this.database.PidParameters.TryGetParameter(id, name, out parameter))
             {
                 return;
             }
@@ -112,10 +116,10 @@ namespace PcmHacking
             this.profile.AddColumn(column);
         }
 
-        private void AddRamParameter(string id, string units)
+        private void AddRamParameter(string id, string name, string units)
         {
             RamParameter parameter;
-            if (!this.database.RamParameters.TryGetParameter(id, out parameter))
+            if (!this.database.RamParameters.TryGetParameter(id, name, out parameter))
             {
                 return;
             }
@@ -135,10 +139,10 @@ namespace PcmHacking
             this.profile.AddColumn(column);
         }
 
-        private void AddMathParameter(string id, string units)
+        private void AddMathParameter(string id, string name, string units)
         {
             MathParameter parameter;
-            if (!this.database.MathParameters.TryGetParameter(id, out parameter))
+            if (!this.database.MathParameters.TryGetParameter(id, name, out parameter))
             {
                 return;
             }

--- a/Apps/PcmLibrary/Logging/LogProfileWriter.cs
+++ b/Apps/PcmLibrary/Logging/LogProfileWriter.cs
@@ -36,6 +36,7 @@ namespace PcmHacking
                     {
                         XElement element = new XElement("PidParameter");
                         element.SetAttributeValue("id", column.Parameter.Id);
+                        element.SetAttributeValue("name", column.Parameter.Name);
                         element.SetAttributeValue("units", column.Conversion.Units);
                         pidParameters.Add(element);
                     }
@@ -50,6 +51,7 @@ namespace PcmHacking
                     {
                         XElement element = new XElement("RamParameter");
                         element.SetAttributeValue("id", column.Parameter.Id);
+                        element.SetAttributeValue("name", column.Parameter.Name);
                         element.SetAttributeValue("units", column.Conversion.Units);
                         ramParameters.Add(element);
                     }
@@ -64,6 +66,7 @@ namespace PcmHacking
                     {
                         XElement element = new XElement("MathParameter");
                         element.SetAttributeValue("id", column.Parameter.Id);
+                        element.SetAttributeValue("name", column.Parameter.Name);
                         element.SetAttributeValue("units", column.Conversion.Units);
                         mathParameters.Add(element);
                     }

--- a/Apps/PcmLibrary/Logging/Parameter.cs
+++ b/Apps/PcmLibrary/Logging/Parameter.cs
@@ -98,7 +98,7 @@ namespace PcmHacking
     /// <summary>
     /// Base class for various parameter types (PID, RAM, Math)
     /// </summary>
-    public abstract class Parameter
+    public abstract class Parameter : IEqualityComparer<Parameter>
     {
         public string Id { get; protected set; }
         public string Name { get; protected set; }
@@ -126,6 +126,16 @@ namespace PcmHacking
         }
 
         public abstract bool IsSupported(uint osid);
+
+        public bool Equals(Parameter x, Parameter y)
+        {
+            return x.Id == y.Id && x.Name == y.Name;
+        }
+
+        public int GetHashCode(Parameter obj)
+        {
+            return HashCode.Combine(obj.Id, obj.Name);
+        }
     }
 
     /// <summary>

--- a/Apps/PcmLibrary/Logging/ParameterDatabase.cs
+++ b/Apps/PcmLibrary/Logging/ParameterDatabase.cs
@@ -13,15 +13,19 @@ namespace PcmHacking
     {
         public class ParameterTable<T> where T : Parameter
         {
-            private Dictionary<string, T> dictionary = new Dictionary<string, T>();
+            private List<T> table = new List<T>();
+
             public void Add(string id, T parameter)
             {
-                this.dictionary[id] = parameter;
+                this.table.Add(parameter);
             }
 
-            public bool TryGetParameter(string id, out T parameter)
+            public bool TryGetParameter(string id, string name, out T parameter)
             {
-                return this.dictionary.TryGetValue(id, out parameter);
+                //String.IsNullOrEmpty(name) is to handle cases where old profiles are being loaded, because we didnt test for that before.
+                parameter = this.table.FirstOrDefault(x => x.Id == id && (x.Name == name || String.IsNullOrEmpty(name))); 
+
+                return parameter != null;
             }
         }
 

--- a/Apps/PcmLibrary/PcmLibrary.csproj
+++ b/Apps/PcmLibrary/PcmLibrary.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="DynamicExpresso.Core" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />

--- a/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
+++ b/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
@@ -154,9 +154,10 @@ namespace PcmHacking
                 this.serialPortList.Items.Add(portInfo);
             }
 
-            // This is useful for testing without an actual PCM. 
-            // You'll need to uncomment a line in FillSerialDeviceList as well as this one.
-            // this.serialPortList.Items.Add(MockPort.PortName);
+            // This is useful for testing without an actual PCM.
+#if DEBUG
+            this.serialPortList.Items.Add(MockPort.PortName);
+#endif
         }
 
         /// <summary>
@@ -171,8 +172,9 @@ namespace PcmHacking
             this.serialDeviceList.Items.Add(OBDXProDevice.DeviceType);
 
             // This is useful for testing without an actual PCM.
-            // You'll need to uncomment a line in FillPortList as well as this one.
-            // this.serialDeviceList.Items.Add(MockDevice.DeviceType);
+#if DEBUG
+            this.serialDeviceList.Items.Add(MockDevice.DeviceType);
+#endif
         }
 
         /// <summary>
@@ -249,6 +251,13 @@ namespace PcmHacking
         /// </summary>
         private void serialPortList_SelectedIndexChanged(object sender, EventArgs e)
         {
+            //mock port isnt a SerialPortInfo
+            if (this.serialPortList.SelectedItem is String)
+            {
+                this.SerialPort = this.serialPortList.SelectedItem as String;
+                return;
+            }
+
             this.SerialPort = (this.serialPortList.SelectedItem as SerialPortInfo)?.PortName;
         }
 

--- a/Apps/PcmLogger/MainForm.ParameterGrid.cs
+++ b/Apps/PcmLogger/MainForm.ParameterGrid.cs
@@ -8,7 +8,7 @@ namespace PcmHacking
 {
     public partial class MainForm
     {
-        private Dictionary<string, DataGridViewRow> parameterIdsToRows;
+        //private Dictionary<string, DataGridViewRow> parameterIdsToRows;
         private ParameterDatabase database;
         private bool suspendSelectionEvents = true;
 
@@ -28,8 +28,6 @@ namespace PcmHacking
                 throw new InvalidDataException("Unable to load parameters from XML: " + errorMessage);
             }
 
-            this.parameterIdsToRows = new Dictionary<string, DataGridViewRow>();
-
             foreach (Parameter parameter in this.database.Parameters)
             {
                 if (!parameter.IsSupported(osid))
@@ -38,20 +36,24 @@ namespace PcmHacking
                 }
 
                 DataGridViewRow row = new DataGridViewRow();
+
                 row.CreateCells(this.parameterGrid);
+
                 row.Cells[0].Value = false; // enabled
                 row.Cells[1].Value = parameter;
 
                 DataGridViewComboBoxCell cell = (DataGridViewComboBoxCell)row.Cells[2];
+
                 cell.DisplayMember = "Units";
                 cell.ValueMember = "Units";
+
                 foreach (Conversion conversion in parameter.Conversions)
                 {
                     cell.Items.Add(conversion);
                 }
+
                 row.Cells[2].Value = parameter.Conversions.First();
 
-                this.parameterIdsToRows[parameter.Id] = row;
                 this.parameterGrid.Rows.Add(row);
             }
 
@@ -76,8 +78,9 @@ namespace PcmHacking
 
                 foreach (LogColumn column in this.currentProfile.Columns)
                 {
-                    DataGridViewRow row;
-                    if (this.parameterIdsToRows.TryGetValue(column.Parameter.Id, out row))
+                    DataGridViewRow row = this.parameterGrid.Rows.Cast<DataGridViewRow>().FirstOrDefault(r => r.Cells[1].Value == column.Parameter);
+
+                    if (row != null)
                     {
                         row.Cells[0].Value = true;
 

--- a/Apps/PcmLogger/MainForm.cs
+++ b/Apps/PcmLogger/MainForm.cs
@@ -56,23 +56,18 @@ namespace PcmHacking
         /// </summary>
         public override void AddDebugMessage(string message)
         {
-            string timestamp = DateTime.Now.ToString("hh:mm:ss:fff");
+            if(this.debugLog.InvokeRequired)
+            {
+                var self = new Action<string>(AddDebugMessage);
+                this.BeginInvoke(self, new[] { message });
+                return;
+            }
 
-            Task foreground = Task.Factory.StartNew(
-                delegate ()
-                {
-                    try
-                    {
-                        this.debugLog.AppendText("[" + timestamp + "]  " + message + Environment.NewLine);
-                    }
-                    catch (ObjectDisposedException)
-                    {
-                        // This will happen if the window is closing. Just ignore it.
-                    }
-                },
-                CancellationToken.None,
-                TaskCreationOptions.None,
-                uiThreadScheduler);
+            lock (this)
+            {
+                string timestamp = DateTime.Now.ToString("hh:mm:ss:fff");
+                this.debugLog.AppendText("[" + timestamp + "]  " + message + Environment.NewLine);
+            }
         }
 
         public override void ResetLogs()


### PR DESCRIPTION
A little stream of consciousness here, but essentially I started out wanting a way to fix the issue where if you selected a pid that had the same id as another pid, and then saved and loaded, there was a good chance of haning that other pid selected instead.

This fix is not ideal, IMO. I've basically added name into the key of the parameter. I've made sure that old config files will still load (they will still exhibit that bug, one time, and then they will save with the name as well)

The ideal fix (IMO) would be to rip the load save code out, as well as rejig the parameter database and profile objects to be serializable. After that it would be a single line to load and save both things. Parameters would need to be keyed still (name only, probably), but that would eliminate the issue on load and save, and as well, would enable saving the profile as a list of names only. That is significantly more work, but would enable the use of WPF instead of winforms, and databinding instead of ui-thread calls to update things. Way less code that way.

I've also included several more performance related fixes:

Mock device was not working for several reasons, and (feel free to correct me) IMO just using debug directives is easier and less bug prone than commenting and uncommenting.

there was a garbage collection issue with the ui-thread code to update the debug log.

the mock device was running at full speed ahead, and that was also taxing my poor laptop.

the waitforserial code on the obdxpro device was also using a full processor, a simple reorganize and sleep(1) cut that by 90%, now my laptop can happily log for much longer.


I hope I'm not presuming too much here. Let me know if any of the assumptions that I've made are wrong. I would love to work on modernizing this UI, and adding more to it.

fixes #328