### PR TITLE
revert using directive to control mock device and port

### DIFF
--- a/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
+++ b/Apps/PcmLibraryWindowsForms/DialogBoxes/DevicePicker.cs
@@ -155,9 +155,9 @@ namespace PcmHacking
             }
 
             // This is useful for testing without an actual PCM.
-#if DEBUG
-            this.serialPortList.Items.Add(MockPort.PortName);
-#endif
+            // This is useful for testing without an actual PCM. 
+            // You'll need to uncomment a line in FillSerialDeviceList as well as this one.
+            // this.serialPortList.Items.Add(MockPort.PortName);
         }
 
         /// <summary>
@@ -172,9 +172,8 @@ namespace PcmHacking
             this.serialDeviceList.Items.Add(OBDXProDevice.DeviceType);
 
             // This is useful for testing without an actual PCM.
-#if DEBUG
-            this.serialDeviceList.Items.Add(MockDevice.DeviceType);
-#endif
+            // You'll need to uncomment a line in FillPortList as well as this one.
+            // this.serialDeviceList.Items.Add(MockDevice.DeviceType);
         }
 
         /// <summary>


### PR DESCRIPTION
per: https://github.com/LegacyNsfw/PcmHacks/commit/5f47e146b203636722dd52f7efe7fce7dc22b8ae#r124815628

I've just reverted this, there isnt really a better way to do this than was there if DEBUG is not usable.

additional #defines (MOCKPORT) would have to be removed before submission anyway, changing the project file to add different symbols or build configs is similar in that they would likely have to be removed before submission as well.