### PR TITLE
Fix Comms Mistake

### DIFF
--- a/Apps/PcmLibrary/Messages/Protocol.Kernel.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.Kernel.cs
@@ -135,8 +135,8 @@ namespace PcmHacking
             return new Message(new byte[]
             {
                 Priority.Physical0,
-                DeviceId.Tool,
                 DeviceId.Pcm,
+                DeviceId.Tool,
                 0x3D,
                 0x05,
                 (byte)(baseAddress >> 16),
@@ -158,7 +158,7 @@ namespace PcmHacking
         /// </summary>
         public Message CreateDebugQuery()
         {
-            return new Message(new byte[] { Priority.Physical0, DeviceId.Tool, DeviceId.Pcm, 0x3D, 0xFF });
+            return new Message(new byte[] { Priority.Physical0, DeviceId.Pcm, DeviceId.Tool, 0x3D, 0xFF });
         }
 
         /// <summary>

--- a/Apps/PcmLibrary/Messages/Protocol.ReadWrite.cs
+++ b/Apps/PcmLibrary/Messages/Protocol.ReadWrite.cs
@@ -163,7 +163,7 @@ namespace PcmHacking
         public Response<byte[]> ParsePayload(Message message, int length, int expectedAddress)
         {
             byte[] actual = message.GetBytes();
-            byte[] expected = new byte[] { Priority.Block, DeviceId.Pcm, DeviceId.Tool, Mode.PCMUpload };
+            byte[] expected = new byte[] { Priority.Block, DeviceId.Tool, DeviceId.Pcm, Mode.PCMUpload };
             if (!TryVerifyInitialBytes(actual, expected, out ResponseStatus status))
             {
                 return Response.Create(status, new byte[0]);


### PR DESCRIPTION
Flipped DeviceId.Pcm and DeviceId.Tool in a couple locations to fix my previous mistake.