### PR TITLE
Add ability to identify OBDX type and enforce VPW speed

### DIFF
--- a/Apps/PcmHammer/MainForm.cs
+++ b/Apps/PcmHammer/MainForm.cs
@@ -818,6 +818,16 @@ namespace PcmHacking
                     this.AddUserMessage("Hardware Type: " + pcmInfo.HardwareType.ToString());
                     if (pcmInfo.HardwareType == PcmType.P04)
                     {
+                        //Use this location to set whether a tool should be forced to use 1x!
+                        //OBDX Pro VT should be 1x due to P04 VPW load not high enough when on bench
+                        //Load is right in car, but car modules wake up and cause bus to crash to 1x regardless.
+                        if (Vehicle.DeviceDescription.Contains("OBDX Pro VT"))
+                        {
+                            this.AddUserMessage("OBDX Pro VT and P04 detected, 4x mode disabled.");
+                            Vehicle.Enable4xReadWrite = false;
+                           // DeviceConfiguration.Settings.Enable4xReadWrite = false; // turn off 4x for the VT!
+                        }
+
                         this.AddUserMessage("**********************************************");
                         this.AddUserMessage("WARNING: P04 Support is still in development.");
                         this.AddUserMessage("It may or may not read your P04 correctly.");

--- a/Apps/PcmLibrary/Devices/OBDXProDevice.cs
+++ b/Apps/PcmLibrary/Devices/OBDXProDevice.cs
@@ -24,6 +24,8 @@ namespace PcmHacking
         public bool TimeStampsEnabled = false;
         public bool CRCInReceivedFrame = false;
 
+        
+
         // This default is probably excessive but it should always be
         // overwritten by a call to SetTimeout before use anyhow.
         private VpwSpeed vpwSpeed = VpwSpeed.Standard;
@@ -101,7 +103,7 @@ namespace PcmHacking
 
         public override string GetDeviceType()
         {
-            return DeviceType;
+            return ToolConnected == "" ? DeviceType : ToolConnected;         
         }
 
         public override async Task<bool> Initialize()


### PR DESCRIPTION
As per title. This allows disabling the OBDX Pro VT running at 4x if a P04 tool has been connected.